### PR TITLE
Reduced trigger objects  btag eff

### DIFF
--- a/interface/Producers/TaggedJetUncertaintyShiftProducer.h
+++ b/interface/Producers/TaggedJetUncertaintyShiftProducer.h
@@ -35,6 +35,7 @@ class TaggedJetUncertaintyShiftProducer: public ProducerBase<HttTypes>
 
 		std::map<HttEnumTypes::JetEnergyUncertaintyShiftName, JetCorrectorParameters const*> JetCorParMap;
 		std::map<HttEnumTypes::JetEnergyUncertaintyShiftName, JetCorrectionUncertainty *> JetUncMap;
+		bool jec_shifts_applied;
 
 		KappaEnumTypes::JetIDVersion jetIDVersion;
 		KappaEnumTypes::JetID jetID;

--- a/interface/Producers/TaggedJetUncertaintyShiftProducer.h
+++ b/interface/Producers/TaggedJetUncertaintyShiftProducer.h
@@ -10,7 +10,7 @@
 
 /**
    \brief Producer for jet energy scale corrections (Htt version).
-   
+
    Mostly copied from https://github.com/truggles/FinalStateAnalysis/blob/miniAOD_8_0_25/PatTools/plugins/MiniAODJetFullSystematicsEmbedder.cc
 
    Required config tags
@@ -19,33 +19,30 @@
 */
 class TaggedJetUncertaintyShiftProducer: public ProducerBase<HttTypes>
 {
+	public:
+		typedef typename HttTypes::event_type event_type;
+		typedef typename HttTypes::product_type product_type;
+		typedef typename HttTypes::setting_type setting_type;
 
-public:
+		virtual void Init(setting_type const& settings) override;
+		std::string GetProducerId() const override;
+		virtual void Produce(event_type const& event, product_type& product, setting_type const& settings) const override;
 
-	typedef typename HttTypes::event_type event_type;
-	typedef typename HttTypes::product_type product_type;
-	typedef typename HttTypes::setting_type setting_type;
-	
-	virtual void Init(setting_type const& settings) override;
-	std::string GetProducerId() const override;
-	virtual void Produce(event_type const& event, product_type& product, setting_type const& settings) const override;
+	private:
+		std::string uncertaintyFile;
+		std::vector<std::string> individualUncertainties;
+		std::vector<HttEnumTypes::JetEnergyUncertaintyShiftName> individualUncertaintyEnums;
 
-private:
-	std::string uncertaintyFile;
-	std::vector<std::string> individualUncertainties;
-	std::vector<HttEnumTypes::JetEnergyUncertaintyShiftName> individualUncertaintyEnums;
+		std::map<HttEnumTypes::JetEnergyUncertaintyShiftName, JetCorrectorParameters const*> JetCorParMap;
+		std::map<HttEnumTypes::JetEnergyUncertaintyShiftName, JetCorrectionUncertainty *> JetUncMap;
 
-	std::map<HttEnumTypes::JetEnergyUncertaintyShiftName, JetCorrectorParameters const*> JetCorParMap;
-	std::map<HttEnumTypes::JetEnergyUncertaintyShiftName, JetCorrectionUncertainty *> JetUncMap;
+		KappaEnumTypes::JetIDVersion jetIDVersion;
+		KappaEnumTypes::JetID jetID;
 
-	KappaEnumTypes::JetIDVersion jetIDVersion;
-	KappaEnumTypes::JetID jetID;
+		std::map<std::string, std::vector<float> > lowerPtCuts;
+		std::map<std::string, std::vector<float> > upperAbsEtaCuts;
 
-	std::map<std::string, std::vector<float> > lowerPtCuts;
-	std::map<std::string, std::vector<float> > upperAbsEtaCuts;
-
-	KappaEnumTypes::BTagScaleFactorMethod m_bTagSFMethod;
-	float m_bTagWorkingPoint;
-	BTagSF m_bTagSf;
+		KappaEnumTypes::BTagScaleFactorMethod m_bTagSFMethod;
+		float m_bTagWorkingPoint;
+		BTagSF m_bTagSf;
 };
-

--- a/python/data/ArtusConfigs/Run2Analysis_base.py
+++ b/python/data/ArtusConfigs/Run2Analysis_base.py
@@ -12,7 +12,7 @@ import Kappa.Skimming.datasetsHelperTwopz as datasetsHelperTwopz
 import importlib
 import os
 
-def build_config(nickname):
+def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
   

--- a/python/data/ArtusConfigs/Run2Analysis_base.py
+++ b/python/data/ArtusConfigs/Run2Analysis_base.py
@@ -15,16 +15,16 @@ import os
 def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
-  
-  
+
+
   # define frequently used conditions
   isEmbedded = datasetsHelper.isEmbedded(nickname)
   isData = datasetsHelper.isData(nickname) and (not isEmbedded)
   isTTbar = re.search("TT(To|_|Jets)", nickname)
   isDY = re.search("DY.?JetsToLL", nickname)
   isWjets = re.search("W.?JetsToLNu", nickname)
-  
-  
+
+
   ## fill config:
   # includes
   includes = [
@@ -36,15 +36,15 @@ def build_config(nickname, **kwargs):
   for include_file in includes:
     analysis_config_module = importlib.import_module(include_file)
     config += analysis_config_module.build_config(nickname)
-  
+
   # explicit configuration
   config["SkipEvents"] = 0
   config["EventCount"] = -1
   config["InputIsData"] = "true" if isData else "false"
-  
+
   config["LumiWhiteList"] = [7582]
   config["EventWhitelist"] = [1473388]
-  
+
   BosonPdgIds = {
       "DY.?JetsToLL|EWKZ2Jets|Embedding(2016|MC)" : [
         23
@@ -64,7 +64,7 @@ def build_config(nickname, **kwargs):
   config["BosonPdgIds"] = [0]
   for key, pdgids in BosonPdgIds.items():
     if re.search(key, nickname): config["BosonPdgIds"] = pdgids
-  
+
   config["BosonStatuses"] = [11,62]
   config["DeltaRMatchingRecoElectronGenParticle"] = 0.2
   config["DeltaRMatchingRecoElectronGenTau"] = 0.2
@@ -84,7 +84,7 @@ def build_config(nickname, **kwargs):
   config["MatchGenTauDecayMode"] = "true"
   config["UpdateMetWithCorrectedLeptons"] = "true"
   config["TopPtReweightingStrategy"] = "Run1"
-  
+
   '''config["MetFilter"] = [
         "Flag_HBHENoiseFilter",
         "Flag_HBHENoiseIsoFilter",
@@ -125,16 +125,16 @@ def build_config(nickname, **kwargs):
         "!Flag_badGlobalMuonTaggerMAOD",
         "!Flag_cloneGlobalMuonTaggerMAOD"
     ]
-  
+
   config["OutputPath"] = "output.root"
-  
+
   if isData or isEmbedded:                config["PileupWeightFile"] = "not needed"
   elif re.search(".*Summer16", nickname): config["PileupWeightFile"] = "$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/pileup/Data_Pileup_2016_271036-284044_13TeVMoriond17_23Sep2016ReReco_69p2mbMinBiasXS.root"
   else:                                   config["PileupWeightFile"] = "$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/pileup/Data_Pileup_2015_246908-260627_13TeVFall15MiniAODv2_PromptReco_69mbMinBiasXS.root"
-  
+
   config["BTagScaleFactorFile"] = "$CMSSW_BASE/src/Artus/KappaAnalysis/data/CSVv2_moriond17_BtoH.csv" if re.search("Summer16", nickname) else "$CMSSW_BASE/src/Artus/KappaAnalysis/data/CSVv2_76X.csv"
   config["BTagEfficiencyFile"] = "$CMSSW_BASE/src/Artus/KappaAnalysis/data/tagging_efficiencies_moriond2017.root" if re.search("Summer16", nickname) else "$CMSSW_BASE/src/Artus/KappaAnalysis/data/tagging_efficiencies.root"
-  
+
   config["MetRecoilCorrectorFile"] = "$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/recoilMet/TypeI-PFMet_Run2016BtoH.root"
   config["MetShiftCorrectorFile"] = "$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/recoilMet/MEtSys.root"
   config["MvaMetShiftCorrectorFile"] = "$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/recoilMet/MEtSys.root"
@@ -145,12 +145,12 @@ def build_config(nickname, **kwargs):
   config["DoZptUncertainties"] = False
 
   config["ChooseMvaMet"] = False
-  
+
   if isData or isEmbedded:
     if   re.search("Run2016|Embedding2016", nickname):      config["JsonFiles"] = ["$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"]
     elif re.search("Run2015(C|D)|Embedding2015", nickname): config["JsonFiles"] = ["$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/json/Cert_13TeV_16Dec2015ReReco_Collisions15_25ns_JSON_v2.txt"]
     elif re.search("Run2015B", nickname):                   config["JsonFiles"] = ["$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/json/Cert_13TeV_16Dec2015ReReco_Collisions15_50ns_JSON_v2.txt"]
-    
+
   if re.search("Fall15MiniAODv2", nickname):
     config["SimpleMuTauFakeRateWeightLoose"] = [1.0, 1.0, 1.0, 1.0, 1.0]
     config["SimpleMuTauFakeRateWeightTight"] = [1.0, 1.0, 1.0, 1.0, 1.0]
@@ -162,7 +162,7 @@ def build_config(nickname, **kwargs):
     config["SimpleEleTauFakeRateWeightVLoose"] = [1.213, 1.375]
     config["SimpleEleTauFakeRateWeightTight"] = [1.402, 1.90]
 
-  
+
   # pipelines - channels including systematic shifts
   config["Pipelines"] = jsonTools.JsonDict()
   #config["Pipelines"] += importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2Analysis.ee").build_config(nickname)
@@ -172,6 +172,6 @@ def build_config(nickname, **kwargs):
   config["Pipelines"] += importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2Analysis.mt").build_config(nickname)
   config["Pipelines"] += importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2Analysis.tt").build_config(nickname)
   #config["Pipelines"] += importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2Analysis.inclusive").build_config(nickname)
-  
-  
+
+
   return config

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsBTaggedJetID.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsBTaggedJetID.py
@@ -7,7 +7,7 @@ log = logging.getLogger(__name__)
 import Artus.Utility.jsonTools as jsonTools
 
 
-def build_config(nickname):
+def build_config(nickname, **kwargs):
     config = jsonTools.JsonDict()
 
     # explicit configuration

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsBTaggedJetID.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsBTaggedJetID.py
@@ -15,17 +15,18 @@ def build_config(nickname, **kwargs):
         "https://twiki.cern.ch/twiki/bin/viewauth/CMS/HiggsToTauTauWorking2016#b_tagging",
     ]
 
-    # 2017 settings for CSVv2 algorithm 94X recommendation
+    # 2017 CSVv2
     # config["BTagScaleFactorFile"] = "$CMSSW_BASE/src/Artus/KappaAnalysis/data/CSVv2_94XSF_V2_B_F.csv"
     # config["BTagEfficiencyFile"] = "$CMSSW_BASE/src/Artus/KappaAnalysis/data/tagging_efficiencies_moriond2017.root"
     # config["BTaggedJetCombinedSecondaryVertexName"] = "pfCombinedInclusiveSecondaryVertexV2BJetTags"
     # config["BTaggerWorkingPoints"] = [
-    #  "tight:0.9693",
-    #  "medium:0.8838",
-    #  "loose:0.5803"
+    #     "tight:0.9693",
+    #     "medium:0.8838",
+    #     "loose:0.5803",
     # ]
 
-    # settings for DeepCSV algorithm 94X recommendation (stated to perform better than CSVv2)
+    # TODO: add to the skims: DeepFlavour https://twiki.cern.ch/twiki/bin/view/CMS/DeepJet
+    # Settings for DeepCSV algorithm 94X recommendation (stated to perform better than CSVv2)
     config["BTagScaleFactorFile"] = "$CMSSW_BASE/src/Artus/KappaAnalysis/data/DeepCSV_94XSF_V3_B_F.csv"
     config["BTagEfficiencyFile"] = "$CMSSW_BASE/src/Artus/KappaAnalysis/data/tagging_efficiencies_moriond2017.root"
     config["BTaggedJetCombinedSecondaryVertexName"] = "pfDeepCSVJetTagsprobbb+pfDeepCSVJetTagsprobb"
@@ -35,6 +36,8 @@ def build_config(nickname, **kwargs):
         "loose:0.1522"
     ]
 
+    config["BTagWPs"] = ["medium"]
+
     config["BTaggedJetAbsEtaCut"] = 2.5  # 2017 value
     config["ApplyBTagSF"] = True
     config["JetTaggerUpperCuts"] = []
@@ -42,6 +45,7 @@ def build_config(nickname, **kwargs):
     config["BTagShift"] = 0
     config["BMistagShift"] = 0
 
+    config["ValidTaggedJetsProducerDebug"] = False
     # Further settings taken into account by ValidBTaggedJetsProducer:
     # - Year (should be 2017), written into the 'base' config
 

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsElectronID.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsElectronID.py
@@ -16,8 +16,8 @@ import importlib
 def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   #datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
-  
-  
+
+
   ## fill config:
   # includes
   includes = [
@@ -25,13 +25,13 @@ def build_config(nickname, **kwargs):
   for include_file in includes:
     analysis_config_module = importlib.import_module(include_file)
     config += analysis_config_module.build_config(nickname)
-  
+
   # explicit configuration
   config["ElectronID_documentation"] = "https://twiki.cern.ch/twiki/bin/viewauth/CMS/HiggsToTauTauWorking2015#Electrons"
   config["ElectronReco"] = "mvanontrig"
   config["ElectronID"] = "user"
   config["ElectronIDType"] = "cutbased2015andlater" # still MVA, using boolean functionality of IsCutBased()
-  
+
   # signal electron ID
   config["ElectronIDName"] = "egmGsfElectronIDs:mvaEleID-Fall17-noIso-V1-wp90" # better S/sqrt(B)
   #config["ElectronIDName"] = "egmGsfElectronIDs:mvaEleID-Fall17-iso-V1-wp90" # already has something like a iso cut ---> not good for side-band regions
@@ -46,7 +46,7 @@ def build_config(nickname, **kwargs):
     "egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1-medium",
     "egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1-tight",
   ]
-  
+
   config["ElectronIsoType"] = "user"
   config["ElectronIso"] = "none"
   config["ElectronIsoSignalConeSize"] = 0.3

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsElectronID.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsElectronID.py
@@ -13,7 +13,7 @@ import Artus.Utility.jsonTools as jsonTools
 import importlib
 #import os
 
-def build_config(nickname):
+def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   #datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
   

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsJEC.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsJEC.py
@@ -8,7 +8,7 @@ import re
 import Artus.Utility.jsonTools as jsonTools
 
 
-def build_config(nickname):
+def build_config(nickname, **kwargs):
     config = jsonTools.JsonDict()
 
     config["JEC_documentation"] = [

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsJetID.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsJetID.py
@@ -16,8 +16,8 @@ import importlib
 def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   #datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
-  
-  
+
+
   ## fill config:
   # includes
   includes = [
@@ -25,7 +25,7 @@ def build_config(nickname, **kwargs):
   for include_file in includes:
     analysis_config_module = importlib.import_module(include_file)
     config += analysis_config_module.build_config(nickname)
-  
+
   # explicit configuration
   config["JetID"] = "tight"
   config["JetIDVersion"] = "2017"
@@ -36,6 +36,6 @@ def build_config(nickname, **kwargs):
   config["JetLowerPtCuts"] = ["20.0"]
   config["JetUpperAbsEtaCuts"] = ["4.7"]
   config["JetLeptonLowerDeltaRCut"] = 0.5
-  
+
 
   return config

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsJetID.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsJetID.py
@@ -13,7 +13,7 @@ import Artus.Utility.jsonTools as jsonTools
 import importlib
 #import os
 
-def build_config(nickname):
+def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   #datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
   

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsLooseElectronID.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsLooseElectronID.py
@@ -16,8 +16,8 @@ import importlib
 def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   #datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
-  
-  
+
+
   ## fill config:
   # includes
   includes = [
@@ -26,7 +26,7 @@ def build_config(nickname, **kwargs):
   for include_file in includes:
     analysis_config_module = importlib.import_module(include_file)
     config += analysis_config_module.build_config(nickname)
-  
+
   # explicit configuration
   config["LooseElectronReco"] = "mvanontrig"
   config["LooseElectronID"] = "user"

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsLooseElectronID.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsLooseElectronID.py
@@ -13,7 +13,7 @@ import Artus.Utility.jsonTools as jsonTools
 import importlib
 #import os
 
-def build_config(nickname):
+def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   #datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
   

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsLooseMuonID.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsLooseMuonID.py
@@ -16,8 +16,8 @@ import importlib
 def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   #datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
-  
-  
+
+
   ## fill config:
   # includes
   includes = [
@@ -26,15 +26,15 @@ def build_config(nickname, **kwargs):
   for include_file in includes:
     analysis_config_module = importlib.import_module(include_file)
     config += analysis_config_module.build_config(nickname)
-  
+
   # explicit configuration
   config["LooseMuonID"] = "medium"
-  
+
   config["LooseMuonIsoType"] = "user"
   config["LooseMuonIso"] = "none"
   config["LooseMuonIsoPtSumOverPtUpperThresholdEB"] = 0.3
   config["LooseMuonIsoPtSumOverPtUpperThresholdEE"] = 0.3
-  
+
   config["LooseMuonLowerPtCuts"] = ["10.0"]
   config["LooseMuonUpperAbsEtaCuts"] = ["2.4"]
   config["LooseMuonTrackDxyCut"] = 0.045

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsLooseMuonID.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsLooseMuonID.py
@@ -13,7 +13,7 @@ import Artus.Utility.jsonTools as jsonTools
 import importlib
 #import os
 
-def build_config(nickname):
+def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   #datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
   

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsMinimalPlotlevelFilter_em.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsMinimalPlotlevelFilter_em.py
@@ -16,9 +16,9 @@ import importlib
 def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   #datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
-  
+
   config["PlotlevelFilterExpressionQuantities"] = [
   ]
   config["PlotlevelFilterExpression"] = "(1.0)"
-  
+
   return config

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsMinimalPlotlevelFilter_em.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsMinimalPlotlevelFilter_em.py
@@ -13,7 +13,7 @@ import Artus.Utility.jsonTools as jsonTools
 import importlib
 #import os
 
-def build_config(nickname):
+def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   #datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
   

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsMinimalPlotlevelFilter_et.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsMinimalPlotlevelFilter_et.py
@@ -16,10 +16,10 @@ import importlib
 def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   #datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
-  
+
   config["PlotlevelFilterExpressionQuantities"] = [
     "rerunDiscriminationByIsolationMVAOldDMrun2v1VVLoose2017_2"
   ]
   config["PlotlevelFilterExpression"] = "rerunDiscriminationByIsolationMVAOldDMrun2v1VVLoose2017_2 > 0.5"
-  
+
   return config

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsMinimalPlotlevelFilter_et.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsMinimalPlotlevelFilter_et.py
@@ -13,7 +13,7 @@ import Artus.Utility.jsonTools as jsonTools
 import importlib
 #import os
 
-def build_config(nickname):
+def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   #datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
   

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsMinimalPlotlevelFilter_mm.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsMinimalPlotlevelFilter_mm.py
@@ -9,7 +9,7 @@ import Artus.Utility.jsonTools as jsonTools
 # import Kappa.Skimming.datasetsHelperTwopz as datasetsHelperTwopz
 
 
-def build_config(nickname):
+def build_config(nickname, **kwargs):
     config = jsonTools.JsonDict()
     # datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
 

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsMinimalPlotlevelFilter_mt.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsMinimalPlotlevelFilter_mt.py
@@ -16,10 +16,10 @@ import importlib
 def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   #datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
-  
+
   config["PlotlevelFilterExpressionQuantities"] = [
     "rerunDiscriminationByIsolationMVAOldDMrun2v1VVLoose2017_2"
   ]
   config["PlotlevelFilterExpression"] = "rerunDiscriminationByIsolationMVAOldDMrun2v1VVLoose2017_2 > 0.5"
-  
+
   return config

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsMinimalPlotlevelFilter_mt.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsMinimalPlotlevelFilter_mt.py
@@ -13,7 +13,7 @@ import Artus.Utility.jsonTools as jsonTools
 import importlib
 #import os
 
-def build_config(nickname):
+def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   #datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
   

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsMinimalPlotlevelFilter_tt.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsMinimalPlotlevelFilter_tt.py
@@ -16,11 +16,11 @@ import importlib
 def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   #datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
-  
+
   config["PlotlevelFilterExpressionQuantities"] = [
     "rerunDiscriminationByIsolationMVAOldDMrun2v1VVLoose2017_1",
     "rerunDiscriminationByIsolationMVAOldDMrun2v1VVLoose2017_2"
   ]
   config["PlotlevelFilterExpression"] = "rerunDiscriminationByIsolationMVAOldDMrun2v1VVLoose2017_1 > 0.5 && rerunDiscriminationByIsolationMVAOldDMrun2v1VVLoose2017_2 > 0.5"
-  
+
   return config

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsMinimalPlotlevelFilter_tt.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsMinimalPlotlevelFilter_tt.py
@@ -13,7 +13,7 @@ import Artus.Utility.jsonTools as jsonTools
 import importlib
 #import os
 
-def build_config(nickname):
+def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   #datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
   

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsMuonID.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsMuonID.py
@@ -16,8 +16,8 @@ import importlib
 def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   #datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
-  
-  
+
+
   ## fill config:
   # includes
   includes = [
@@ -25,12 +25,12 @@ def build_config(nickname, **kwargs):
   for include_file in includes:
     analysis_config_module = importlib.import_module(include_file)
     config += analysis_config_module.build_config(nickname)
-  
+
   # explicit configuration
   config["MuonID"] = "medium"
-  
+
   config["MuonIsoTypeUserMode"] = "fromcmsswr04"
-    
+
   config["MuonIsoType"] = "user"
   config["MuonIso"] = "none"
   config["MuonIsoSignalConeSize"] = 0.4

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsMuonID.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsMuonID.py
@@ -13,7 +13,7 @@ import Artus.Utility.jsonTools as jsonTools
 import importlib
 #import os
 
-def build_config(nickname):
+def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   #datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
   

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsTauES.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsTauES.py
@@ -16,8 +16,8 @@ import importlib
 def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   #datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
-  
-  
+
+
   ## fill config:
   # includes
   includes = [
@@ -25,10 +25,10 @@ def build_config(nickname, **kwargs):
   for include_file in includes:
     analysis_config_module = importlib.import_module(include_file)
     config += analysis_config_module.build_config(nickname)
-  
+
   # explicit configuration
   config["TauEnergyCorrection"] = "mssmhtt2016"
-  
+
   if re.search("Run201|Embedding", nickname):
     config["TauEnergyCorrectionOneProng"] = 1.0
     config["TauEnergyCorrectionOneProngPiZeros"] = 1.0
@@ -41,6 +41,6 @@ def build_config(nickname, **kwargs):
     config["TauEnergyCorrectionThreeProng"] = 0.990
     config["TauElectronFakeEnergyCorrectionOneProng"] = 1.0
     config["TauElectronFakeEnergyCorrectionOneProngPiZeros"] = 1.0
-  
+
 
   return config

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsTauES.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsTauES.py
@@ -13,7 +13,7 @@ import Artus.Utility.jsonTools as jsonTools
 import importlib
 #import os
 
-def build_config(nickname):
+def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   #datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
   

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsTauID.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsTauID.py
@@ -16,8 +16,8 @@ import importlib
 def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   #datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
-  
-  
+
+
   ## fill config:
   # includes
   includes = [
@@ -25,7 +25,7 @@ def build_config(nickname, **kwargs):
   for include_file in includes:
     analysis_config_module = importlib.import_module(include_file)
     config += analysis_config_module.build_config(nickname)
-  
+
   # explicit configuration
   #config["TauID_documentation"] = []
   config["TauDiscriminatorIsolationName"] = "byIsolationMVArun2017v2DBoldDMwLTraw2017" # Fall17 trainings

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsTauID.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsTauID.py
@@ -13,7 +13,7 @@ import Artus.Utility.jsonTools as jsonTools
 import importlib
 #import os
 
-def build_config(nickname):
+def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   #datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
   

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsVetoElectronID.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsVetoElectronID.py
@@ -13,7 +13,7 @@ import Artus.Utility.jsonTools as jsonTools
 import importlib
 #import os
 
-def build_config(nickname):
+def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   #datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
   

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsVetoElectronID.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsVetoElectronID.py
@@ -16,8 +16,8 @@ import importlib
 def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   #datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
-  
-  
+
+
   ## fill config:
   # includes
   includes = [
@@ -26,28 +26,28 @@ def build_config(nickname, **kwargs):
   for include_file in includes:
     analysis_config_module = importlib.import_module(include_file)
     config += analysis_config_module.build_config(nickname)
-  
+
   # explicit configuration
   config["VetoElectronReco"] = "none"
   config["VetoElectronID"] = "user"
   config["VetoElectronIDType"] = "cutbased2015andlater"
   # dilepton veto electron ID
   config["VetoElectronIDName"] = "egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1-veto"
-  
+
   config["VetoElectronIsoType"] = "user"
   config["VetoElectronIso"] = "none"
   config["VetoElectronIsoPtSumOverPtUpperThresholdEB"] = 0.3
   config["VetoElectronIsoPtSumOverPtUpperThresholdEE"] = 0.3
-  
+
   config["VetoElectronLowerPtCuts"] = ["15.0"]
   config["VetoElectronUpperAbsEtaCuts"] = ["2.5"]
   config["DiVetoElectronMinDeltaRCut"] = "0.15"
   config["DiVetoElectronVetoMode"] = "veto_os_keep_ss"
   config["DirectIso"] = True
-  
+
   config["ElectronIDList"] = [
   ]
   config["ElectronEtaBinnedEAValues"] = []
   config["ElectronEtaBinsForEA"] = []
-  
+
   return config

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsVetoMuonID.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsVetoMuonID.py
@@ -16,8 +16,8 @@ import importlib
 def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   #datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
-  
-  
+
+
   ## fill config:
   # includes
   includes = [
@@ -26,15 +26,15 @@ def build_config(nickname, **kwargs):
   for include_file in includes:
     analysis_config_module = importlib.import_module(include_file)
     config += analysis_config_module.build_config(nickname)
-  
+
   # explicit configuration
   config["VetoMuonID"] = "loose"
-  
+
   config["VetoMuonIsoType"] = "user"
   config["VetoMuonIso"] = "none"
   config["VetoMuonIsoPtSumOverPtUpperThresholdEB"] = 0.3
   config["VetoMuonIsoPtSumOverPtUpperThresholdEE"] = 0.3
-  
+
   config["VetoMuonLowerPtCuts"] = ["15.0"]
   config["VetoMuonUpperAbsEtaCuts"] = ["2.4"]
   config["DiVetoMuonMinDeltaRCut"] = "0.15"

--- a/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsVetoMuonID.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/Includes/settingsVetoMuonID.py
@@ -13,7 +13,7 @@ import Artus.Utility.jsonTools as jsonTools
 import importlib
 #import os
 
-def build_config(nickname):
+def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   #datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
   

--- a/python/data/ArtusConfigs/Run2MSSM2017/ee.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/ee.py
@@ -15,7 +15,9 @@ import os
 
 import HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Includes.ArtusConfigUtility as ACU
 
-def build_config(nickname):
+def build_config(nickname, **kwargs):
+  btag_eff = True if "sub_analysis" in kwargs and kwargs["sub_analysis"] == "btag-eff" else False
+
   config = jsonTools.JsonDict()
   datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
 

--- a/python/data/ArtusConfigs/Run2MSSM2017/ee.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/ee.py
@@ -18,8 +18,7 @@ import HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Includes.ArtusConfigUtil
 def build_config(nickname):
   config = jsonTools.JsonDict()
   datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
-  
-  
+
   # define frequently used conditions
   isEmbedded = datasetsHelper.isEmbedded(nickname)
   isData = datasetsHelper.isData(nickname) and (not isEmbedded)
@@ -27,8 +26,8 @@ def build_config(nickname):
   isDY = re.search("DY.?JetsToLLM(50|150)", nickname)
   isWjets = re.search("W.?JetsToLNu", nickname)
   isHtt = re.search("HToTauTau", nickname)
-  
-  
+
+
   ## fill config:
   # includes
   includes = [
@@ -47,7 +46,7 @@ def build_config(nickname):
   for include_file in includes:
     analysis_config_module = importlib.import_module(include_file)
     config += analysis_config_module.build_config(nickname)
-  
+
   # explicit configuration
   config["Channel"] = "EE"
   config["MinNElectrons"] = 2
@@ -132,7 +131,7 @@ def build_config(nickname):
   config["InvalidateNonMatchingTaus"] = False
   config["InvalidateNonMatchingJets"] = False
   config["DirectIso"] = True
-  
+
   config["Quantities"] = importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2MSSM.Includes.syncQuantities").build_list()
   config["Quantities"].extend(importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Includes.weightQuantities").build_list())
   #config["Quantities"].extend(importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Includes.MVAInputQuantities").build_list())
@@ -151,10 +150,10 @@ def build_config(nickname):
       "muR0p5_muF2p0_weight",
       "muR0p5_muF0p5_weight"
   ])
-  
+
   config["OSChargeLeptons"] = True
   config["TopPtReweightingStrategy"] = "Run1"
-  
+
   config["Processors"] = [                                  "producer:HttValidLooseElectronsProducer",
                                                             "producer:HttValidLooseMuonsProducer",
                                                             "producer:HltProducer",
@@ -185,7 +184,7 @@ def build_config(nickname):
   if not isData:               config["Processors"].append( #"producer:TriggerWeightProducer", "producer:IdentificationWeightProducer"
                                                             "producer:RooWorkspaceWeightProducer")
   config["Processors"].append(                              "producer:EventWeightProducer")
-  
+
   config["AddGenMatchedParticles"] = True
   config["AddGenMatchedTaus"] = True
   config["AddGenMatchedTauJets"] = True
@@ -199,7 +198,7 @@ def build_config(nickname):
                          #"KappaTaggedJetsConsumer",
                          #"RunTimeConsumer",
                          #"PrintEventsConsumer"
-  
-  
+
+
   # pipelines - systematic shifts
   return ACU.apply_uncertainty_shift_configs('ee', config, importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2MSSM.syst_shifts_nom").build_config(nickname))

--- a/python/data/ArtusConfigs/Run2MSSM2017/em.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/em.py
@@ -230,8 +230,7 @@ def build_config(nickname):
         "HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v:hltMu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLMuonlegL3IsoFiltered23",
         "HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v:hltMu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZFilter"
       ]
-  
-  config["BTagWPs"] = ["medium"]
+
   config["InvalidateNonMatchingElectrons"] = False
   config["InvalidateNonMatchingMuons"] = False
   config["InvalidateNonMatchingTaus"] = False

--- a/python/data/ArtusConfigs/Run2MSSM2017/em.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/em.py
@@ -15,7 +15,9 @@ import os
 
 import HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Includes.ArtusConfigUtility as ACU
 
-def build_config(nickname):
+def build_config(nickname, **kwargs):
+  btag_eff = True if "sub_analysis" in kwargs and kwargs["sub_analysis"] == "btag-eff" else False
+
   config = jsonTools.JsonDict()
   datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
 

--- a/python/data/ArtusConfigs/Run2MSSM2017/em.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/em.py
@@ -276,6 +276,9 @@ def build_config(nickname, **kwargs):
   #                                                            "producer:TaggedJetCorrectionsProducer",
                                                               "producer:ValidTaggedJetsProducer",
                                                               "producer:ValidBTaggedJetsProducer"))
+
+  if btag_eff: config["ProcessorsBtagEff"] = copy.deepcp(config["Processors"])
+
   if not isData:                 config["Processors"].append( "producer:HttValidGenTausProducer")
   if not (isEmbedded):           config["Processors"].append( "producer:MetCorrector")
   config["Processors"].extend((                               "producer:TauTauRestFrameSelector",
@@ -292,12 +295,21 @@ def build_config(nickname, **kwargs):
   #config["Processors"].extend((                               "producer:EmuQcdWeightProducer",
   config["Processors"].append(
                                                               "producer:EventWeightProducer")#)
-    
+
   config["AddGenMatchedParticles"] = True
   config["BranchGenMatchedElectrons"] = True
   config["BranchGenMatchedMuons"] = True
   config["Consumers"] = ["KappaLambdaNtupleConsumer",
                          "cutflow_histogram"]
-  
+
+  if btag_eff:
+     config["Processors"] = copy.deepcp(config["ProcessorsBtagEff"])
+
+     btag_eff_unwanted = ["KappaLambdaNtupleConsumer", "CutFlowTreeConsumer", "KappaElectronsConsumer", "KappaTausConsumer", "KappaTaggedJetsConsumer", "RunTimeConsumer", "PrintEventsConsumer"]
+     for unwanted in btag_eff_unwanted:
+      if unwanted in config["Consumers"]: config["Consumers"].remove(unwanted)
+
+     config["Consumers"].append("BTagEffConsumer")
+
   # pipelines - systematic shifts
   return ACU.apply_uncertainty_shift_configs('em', config, importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2MSSM2017.syst_shifts_nom").build_config(nickname))

--- a/python/data/ArtusConfigs/Run2MSSM2017/em.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/em.py
@@ -18,8 +18,7 @@ import HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Includes.ArtusConfigUtil
 def build_config(nickname):
   config = jsonTools.JsonDict()
   datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
-  
-  
+
   # define frequently used conditions
   isEmbedded = datasetsHelper.isEmbedded(nickname)
   isData = datasetsHelper.isData(nickname) and (not isEmbedded)
@@ -27,7 +26,7 @@ def build_config(nickname):
   isDY = re.search("DY.?JetsToLLM(10to50|50)", nickname)
   isWjets = re.search("W.?JetsToLNu", nickname)
   isSignal = re.search("HToTauTau",nickname)
-  
+
   ## fill config:
   # includes
   includes = [
@@ -45,7 +44,7 @@ def build_config(nickname):
   for include_file in includes:
     analysis_config_module = importlib.import_module(include_file)
     config += analysis_config_module.build_config(nickname)
-  
+
   # explicit configuration
   config["Channel"] = "EM"
   config["MinNElectrons"] = 1
@@ -133,7 +132,7 @@ def build_config(nickname):
           "0:isoWeight",
           "0:idWeight",
           "0:triggerWeight"
-          ] 
+          ]
     config["EmbeddedWeightWorkspaceObjectNames"]=[
           "0:m_sel_trg_ratio",
           "1:m_looseiso_ratio",
@@ -206,14 +205,14 @@ def build_config(nickname):
       "0:$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/triggerWeights/triggerEfficiency_dummy.root",
       "1:$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/triggerWeights/triggerEfficiency_dummy.root",
       "1:$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/triggerWeights/triggerEfficiency_dummy.root"]
-  
+
   config["TriggerEfficiencyMode"] = "correlate_triggers"
   config["IdentificationEfficiencyMode"] = "multiply_weights"
   config["EventWeight"] = "eventWeight"
 
 
   config["TauTauRestFrameReco"] = "collinear_approximation"
-  
+
   config["ElectronTriggerFilterNames"] = [
         "HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v:hltMu8TrkIsoVVLEle23CaloIdLTrackIdLIsoVLElectronlegTrackIsoFilter",
         "HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v:hltMu8TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZFilter",
@@ -236,7 +235,7 @@ def build_config(nickname):
   config["InvalidateNonMatchingTaus"] = False
   config["InvalidateNonMatchingJets"] = False
   config["DirectIso"] = True
-  
+
   config["Quantities"] = importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2MSSM2017.Includes.syncQuantities").build_list()
   config["Quantities"].extend(importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Includes.weightQuantities").build_list())
   config["Quantities"].extend(importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2MSSM2017.Includes.lheWeights").build_list())
@@ -249,10 +248,10 @@ def build_config(nickname):
     config["Quantities"].extend([
           "muonEffTrgWeight"
           ])
-  
+
   config["OSChargeLeptons"] = True
   config["TopPtReweightingStrategy"] = "Run2"
-  
+
   config["Processors"] = []
   if not (isEmbedded):           config["Processors"].append( "producer:ElectronCorrectionsProducer")
   config["Processors"].extend((                               "producer:HttValidLooseElectronsProducer",

--- a/python/data/ArtusConfigs/Run2MSSM2017/et.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/et.py
@@ -291,6 +291,9 @@ def build_config(nickname, **kwargs):
   #                                                            "producer:TaggedJetCorrectionsProducer",
                                                               "producer:ValidTaggedJetsProducer",
                                                               "producer:ValidBTaggedJetsProducer"))
+
+  if btag_eff: config["ProcessorsBtagEff"] = copy.deepcp(config["Processors"])
+
   if not (isEmbedded):           config["Processors"].append( "producer:MetCorrector")
   config["Processors"].extend((                               "producer:TauTauRestFrameSelector",
                                                               "producer:DiLeptonQuantitiesProducer",
@@ -315,6 +318,15 @@ def build_config(nickname, **kwargs):
   config["BranchGenMatchedTaus"] = True
   config["Consumers"] = ["KappaLambdaNtupleConsumer",
                          "cutflow_histogram"]
-  
+
+  if btag_eff:
+     config["Processors"] = copy.deepcp(config["ProcessorsBtagEff"])
+
+     btag_eff_unwanted = ["KappaLambdaNtupleConsumer", "CutFlowTreeConsumer", "KappaElectronsConsumer", "KappaTausConsumer", "KappaTaggedJetsConsumer", "RunTimeConsumer", "PrintEventsConsumer"]
+     for unwanted in btag_eff_unwanted:
+      if unwanted in config["Consumers"]: config["Consumers"].remove(unwanted)
+
+     config["Consumers"].append("BTagEffConsumer")
+
   # pipelines - systematic shifts
   return ACU.apply_uncertainty_shift_configs('et', config, importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2MSSM2017.syst_shifts_nom").build_config(nickname))

--- a/python/data/ArtusConfigs/Run2MSSM2017/et.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/et.py
@@ -15,7 +15,9 @@ import os
 
 import HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Includes.ArtusConfigUtility as ACU
 
-def build_config(nickname):
+def build_config(nickname, **kwargs):
+  btag_eff = True if "sub_analysis" in kwargs and kwargs["sub_analysis"] == "btag-eff" else False
+
   config = jsonTools.JsonDict()
   datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
 

--- a/python/data/ArtusConfigs/Run2MSSM2017/et.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/et.py
@@ -240,7 +240,7 @@ def build_config(nickname):
           "HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_v:hltPFTau180TrackPt50LooseAbsOrRelMediumHighPtRelaxedIsoIso",
           "HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_v:hltSelectedPFTau180MediumChargedIsolationL1HLTMatched"
     ]
-  config["BTagWPs"] = ["medium"]
+
   config["InvalidateNonMatchingElectrons"] = False
   config["InvalidateNonMatchingMuons"] = False
   config["InvalidateNonMatchingTaus"] = False

--- a/python/data/ArtusConfigs/Run2MSSM2017/et.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/et.py
@@ -18,8 +18,7 @@ import HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Includes.ArtusConfigUtil
 def build_config(nickname):
   config = jsonTools.JsonDict()
   datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
-  
-  
+
   # define frequently used conditions
   isEmbedded = datasetsHelper.isEmbedded(nickname)
   isData = datasetsHelper.isData(nickname) and (not isEmbedded)
@@ -27,7 +26,7 @@ def build_config(nickname):
   isDY = re.search("DY.?JetsToLLM(10to50|50)", nickname)
   isWjets = re.search("W.?JetsToLNu", nickname)
   isSignal = re.search("HToTauTau",nickname)
-  
+
   ## fill config:
   # includes
   includes = [
@@ -47,7 +46,7 @@ def build_config(nickname):
   for include_file in includes:
     analysis_config_module = importlib.import_module(include_file)
     config += analysis_config_module.build_config(nickname)
-  
+
   # explicit configuration
   config["Channel"] = "ET"
   config["MinNElectrons"] = 1
@@ -61,7 +60,7 @@ def build_config(nickname):
           "HLT_Ele24_eta2p1_WPTight_Gsf_LooseChargedIsoPFTau30_eta2p1_CrossL1",
           "HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1",
     ]
-  
+
   config["TauID"] = "TauIDRecommendation13TeV"
   config["TauUseOldDMs"] = True
   config["ElectronScaleAndSmearUsed"] = True
@@ -156,7 +155,7 @@ def build_config(nickname):
   if isEmbedded:
     config["RooWorkspace"] = "$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/scaleFactorWeights/htt_scalefactors_v17_4_embedded.root"
     config["EmbeddedWeightWorkspace"] = "$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/scaleFactorWeights/htt_scalefactors_v17_4_embedded.root"
-    config["EmbeddedWeightWorkspaceWeightNames"]=[] 
+    config["EmbeddedWeightWorkspaceWeightNames"]=[]
     config["EmbeddedWeightWorkspaceWeightNames"].extend((
           "0:muonEffTrgWeight",
           "0:isoWeight",
@@ -176,7 +175,7 @@ def build_config(nickname):
           "0:e_pt,e_eta,e_iso",
           "0:e_pt,e_eta",
           "0:e_pt,e_eta,e_iso"
-          ))  
+          ))
   else:
     config["RooWorkspace"] = "$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/scaleFactorWeights/htt_scalefactors_v17_1.root"
     config["RooWorkspaceWeightNames"] = [
@@ -186,7 +185,7 @@ def build_config(nickname):
         "0:singleTriggerDataEfficiencyWeight",
         "0:singleTriggerMCEfficiencyWeightKIT",
         "0:singleTriggerDataEfficiencyWeightKIT",
-    
+
         "0:idWeight",
         "0:isoWeight",
         "0:trackWeight",
@@ -210,7 +209,7 @@ def build_config(nickname):
         "0:e_pt,e_eta",
         "0:e_pt,e_eta",
         "0:e_pt,e_eta",
-    
+
         "0:e_pt,e_eta",
         "0:e_pt,e_eta",
         "0:e_pt,e_eta",
@@ -246,7 +245,7 @@ def build_config(nickname):
   config["InvalidateNonMatchingTaus"] = False
   config["InvalidateNonMatchingJets"] = False
   config["DirectIso"] = True
-  
+
   config["Quantities"] = importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2MSSM2017.Includes.syncQuantities").build_list()
   config["Quantities"].extend(importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Includes.weightQuantities").build_list())
   config["Quantities"].extend(importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2MSSM2017.Includes.zptQuantities").build_list())
@@ -260,10 +259,10 @@ def build_config(nickname):
     config["Quantities"].extend(importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2MSSM2017.Includes.embeddedDecayModeWeightQuantities").build_list())
     config["Quantities"].extend([
           "muonEffTrgWeight"
-          ])  
+          ])
   config["OSChargeLeptons"] = True
   config["TopPtReweightingStrategy"] = "Run2"
-  
+
   config["Processors"] =                                     []# if (isData or isEmbedded) else ["producer:ElectronCorrectionsProducer"]
   if not (isEmbedded):           config["Processors"].append( "producer:ElectronCorrectionsProducer")
   config["Processors"].extend((                               "producer:HttValidLooseElectronsProducer",
@@ -306,7 +305,7 @@ def build_config(nickname):
   if not isData:                 config["Processors"].append( "producer:TauTrigger2017EfficiencyProducer")
   #if not isEmbedded:             config["Processors"].append( "producer:JetToTauFakesProducer")
   config["Processors"].append(                                "producer:EventWeightProducer")
-  
+
   config["AddGenMatchedParticles"] = True
   config["AddGenMatchedTaus"] = True
   config["AddGenMatchedTauJets"] = True

--- a/python/data/ArtusConfigs/Run2MSSM2017/mm.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/mm.py
@@ -237,7 +237,6 @@ def build_config(nickname):
         ]
 
     # BTag setting
-    config["BTagWPs"] = ["medium"]
     config["InvalidateNonMatchingElectrons"] = False
     config["InvalidateNonMatchingMuons"] = False
     config["InvalidateNonMatchingTaus"] = False

--- a/python/data/ArtusConfigs/Run2MSSM2017/mm.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/mm.py
@@ -5,6 +5,7 @@ import logging
 import Artus.Utility.logger as logger
 log = logging.getLogger(__name__)
 
+import copy
 import re
 import importlib
 import os
@@ -14,7 +15,9 @@ import Kappa.Skimming.datasetsHelperTwopz as datasetsHelperTwopz
 import HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Includes.ArtusConfigUtility as ACU
 
 
-def build_config(nickname):
+def build_config(nickname, **kwargs):
+    btag_eff = True if "sub_analysis" in kwargs and kwargs["sub_analysis"] == "btag-eff" else False
+
     config = jsonTools.JsonDict()
     datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
 

--- a/python/data/ArtusConfigs/Run2MSSM2017/mm.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/mm.py
@@ -78,6 +78,7 @@ def build_config(nickname):
         ]
 
     # RooWorksapce for Trigger&ID SFs of lepton in the final state
+    # https://github.com/CMS-HTT/CorrectionsWorkspace
     config["RooWorkspace"] = "$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/scaleFactorWeights/htt_scalefactors_v17_1.root"
     config["RooWorkspaceWeightNames"] = [
         "0:crossTriggerMCEfficiencyWeight",

--- a/python/data/ArtusConfigs/Run2MSSM2017/mm.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/mm.py
@@ -302,7 +302,7 @@ def build_config(nickname, **kwargs):
         "producer:Run2DecayChannelProducer",
         # "producer:MvaMetSelector",
         "producer:DiVetoMuonVetoProducer",
-        "producer:TaggedJetCorrectionsProducer",
+        # "producer:TaggedJetCorrectionsProducer",  # maybe needs to go one level lower
         "producer:ValidTaggedJetsProducer",
         "producer:ValidBTaggedJetsProducer",
     ))

--- a/python/data/ArtusConfigs/Run2MSSM2017/mm.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/mm.py
@@ -307,6 +307,8 @@ def build_config(nickname, **kwargs):
         "producer:ValidBTaggedJetsProducer",
     ))
 
+    if btag_eff: config["ProcessorsBtagEff"] = copy.deepcp(config["Processors"])
+
     if isDY or isWjets or isSignal:
         config["Processors"].append(
             "producer:MetCorrector",
@@ -356,6 +358,15 @@ def build_config(nickname, **kwargs):
         # "RunTimeConsumer",
         # "PrintEventsConsumer",
     ]
+
+    if btag_eff:
+        config["Processors"] = copy.deepcp(config["ProcessorsBtagEff"])
+
+        btag_eff_unwanted = ["KappaLambdaNtupleConsumer", "CutFlowTreeConsumer", "KappaElectronsConsumer", "KappaTausConsumer", "KappaTaggedJetsConsumer", "RunTimeConsumer", "PrintEventsConsumer"]
+        for unwanted in btag_eff_unwanted:
+            if unwanted in config["Consumers"]: config["Consumers"].remove(unwanted)
+
+        config["Consumers"].append("BTagEffConsumer")
 
     # pipelines - systematic shifts
     return ACU.apply_uncertainty_shift_configs(

--- a/python/data/ArtusConfigs/Run2MSSM2017/mt.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/mt.py
@@ -15,7 +15,9 @@ import os
 
 import HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Includes.ArtusConfigUtility as ACU
 
-def build_config(nickname):
+def build_config(nickname, **kwargs):
+  btag_eff = True if "sub_analysis" in kwargs and kwargs["sub_analysis"] == "btag-eff" else False
+
   config = jsonTools.JsonDict()
   datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
 

--- a/python/data/ArtusConfigs/Run2MSSM2017/mt.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/mt.py
@@ -18,8 +18,7 @@ import HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Includes.ArtusConfigUtil
 def build_config(nickname):
   config = jsonTools.JsonDict()
   datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
-  
-  
+
   # define frequently used conditions
   isEmbedded = datasetsHelper.isEmbedded(nickname)
   isData = datasetsHelper.isData(nickname) and (not isEmbedded)
@@ -27,7 +26,7 @@ def build_config(nickname):
   isDY = re.search("DY.?JetsToLLM(10to50|50)", nickname)
   isWjets = re.search("W.?JetsToLNu", nickname)
   isSignal = re.search("HToTauTau",nickname)
-  
+
   ## fill config:
   # includes
   includes = [
@@ -47,7 +46,7 @@ def build_config(nickname):
   for include_file in includes:
     analysis_config_module = importlib.import_module(include_file)
     config += analysis_config_module.build_config(nickname)
-  
+
   # explicit configuration
   config["Channel"] = "MT"
   config["MinNMuons"] = 1
@@ -59,7 +58,7 @@ def build_config(nickname):
           "HLT_IsoMu20_eta2p1_LooseChargedIsoPFTau27_eta2p1_CrossL1",
           "HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1",
   ]
-  
+
   config["TauID"] = "TauIDRecommendation13TeV"
   config["TauUseOldDMs"] = True
   config["MuonLowerPtCuts"] = ["10.0"]
@@ -178,7 +177,7 @@ def build_config(nickname):
         "0:singleTriggerDataEfficiencyWeight",
         "0:singleTriggerMCEfficiencyWeightKIT",
         "0:singleTriggerDataEfficiencyWeightKIT",
-  
+
         "0:isoWeight",
         "0:idWeight",
 #        "0:trackWeight", # new recommendation for 2017 data/MC is to remove it (will result in SF = 1.0).
@@ -190,7 +189,7 @@ def build_config(nickname):
         "0:m_trg_SingleMu_Mu24ORMu27_desy_data",
         "0:m_trg24or27_mc",
         "0:m_trg24or27_data",
-  
+
         "0:m_iso_ratio",
         "0:m_id_ratio",
 #        "0:m_trk_ratio",
@@ -202,7 +201,7 @@ def build_config(nickname):
         "0:m_pt,m_eta",
         "0:m_pt,m_eta",
         "0:m_pt,m_eta",
-  
+
         "0:m_pt,m_eta",
         "0:m_pt,m_eta",
 #        "0:m_eta",
@@ -235,7 +234,7 @@ def build_config(nickname):
   config["InvalidateNonMatchingTaus"] = False
   config["InvalidateNonMatchingJets"] = False
   config["DirectIso"] = True
-  
+
   config["Quantities"] = importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2MSSM2017.Includes.syncQuantities").build_list()
   config["Quantities"].extend(importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Includes.weightQuantities").build_list())
   config["Quantities"].extend(importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2MSSM2017.Includes.zptQuantities").build_list())
@@ -249,10 +248,10 @@ def build_config(nickname):
     config["Quantities"].extend(importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2MSSM2017.Includes.embeddedDecayModeWeightQuantities").build_list())
     config["Quantities"].extend([
           "muonEffTrgWeight"
-          ])   
+          ])
   config["OSChargeLeptons"] = True
   config["TopPtReweightingStrategy"] = "Run2"
-  
+
   config["Processors"] =   []#                                  ["producer:MuonCorrectionsProducer"] if isEmbedded else []
   if not (isEmbedded):           config["Processors"].append( "producer:ElectronCorrectionsProducer")
   config["Processors"].extend((                               "producer:HttValidLooseElectronsProducer",
@@ -296,7 +295,8 @@ def build_config(nickname):
   if not isData:                 config["Processors"].append( "producer:TauTrigger2017EfficiencyProducer")
   #if not isEmbedded:             config["Processors"].append( "producer:JetToTauFakesProducer")
   config["Processors"].append(                                "producer:EventWeightProducer")
-  
+
+
   config["AddGenMatchedParticles"] = True
   config["AddGenMatchedTaus"] = True
   config["AddGenMatchedTauJets"] = True

--- a/python/data/ArtusConfigs/Run2MSSM2017/mt.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/mt.py
@@ -229,7 +229,7 @@ def build_config(nickname):
           "HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_v:hltPFTau180TrackPt50LooseAbsOrRelMediumHighPtRelaxedIsoIso",
           "HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_v:hltSelectedPFTau180MediumChargedIsolationL1HLTMatched"
     ]
-  config["BTagWPs"] = ["medium"]
+
   config["InvalidateNonMatchingElectrons"] = False
   config["InvalidateNonMatchingMuons"] = False
   config["InvalidateNonMatchingTaus"] = False

--- a/python/data/ArtusConfigs/Run2MSSM2017/mt.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/mt.py
@@ -280,6 +280,9 @@ def build_config(nickname, **kwargs):
   #                                                            "producer:TaggedJetCorrectionsProducer",
                                                               "producer:ValidTaggedJetsProducer",
                                                               "producer:ValidBTaggedJetsProducer"))
+
+  if btag_eff: config["ProcessorsBtagEff"] = copy.deepcp(config["Processors"])
+
   if not (isData or isEmbedded): config["Processors"].append( "producer:MetCorrector")
   config["Processors"].extend((                               "producer:TauTauRestFrameSelector",
                                                               "producer:DiLeptonQuantitiesProducer",
@@ -306,6 +309,15 @@ def build_config(nickname, **kwargs):
   config["BranchGenMatchedTaus"] = True
   config["Consumers"] = ["KappaLambdaNtupleConsumer",
                          "cutflow_histogram"]
-  
+
+  if btag_eff:
+     config["Processors"] = copy.deepcp(config["ProcessorsBtagEff"])
+
+     btag_eff_unwanted = ["KappaLambdaNtupleConsumer", "CutFlowTreeConsumer", "KappaElectronsConsumer", "KappaTausConsumer", "KappaTaggedJetsConsumer", "RunTimeConsumer", "PrintEventsConsumer"]
+     for unwanted in btag_eff_unwanted:
+      if unwanted in config["Consumers"]: config["Consumers"].remove(unwanted)
+
+     config["Consumers"].append("BTagEffConsumer")
+
   # pipelines - systematic shifts
   return ACU.apply_uncertainty_shift_configs('mt', config, importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2MSSM2017.syst_shifts_nom").build_config(nickname))

--- a/python/data/ArtusConfigs/Run2MSSM2017/tt.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/tt.py
@@ -234,6 +234,9 @@ def build_config(nickname, **kwargs):
   #                                                            "producer:TaggedJetCorrectionsProducer",
                                                               "producer:ValidTaggedJetsProducer",
                                                               "producer:ValidBTaggedJetsProducer"))
+
+  if btag_eff: config["ProcessorsBtagEff"] = copy.deepcp(config["Processors"])
+
   if not (isData or isEmbedded):  config["Processors"].append("producer:MetCorrector")
   config["Processors"].extend((                               "producer:SimpleEleTauFakeRateWeightProducer",
                                                               "producer:SimpleMuTauFakeRateWeightProducer"))
@@ -256,6 +259,15 @@ def build_config(nickname, **kwargs):
   config["BranchGenMatchedTaus"] = True
   config["Consumers"] = ["KappaLambdaNtupleConsumer",
                          "cutflow_histogram"]
-  
+
+  if btag_eff:
+     config["Processors"] = copy.deepcp(config["ProcessorsBtagEff"])
+
+     btag_eff_unwanted = ["KappaLambdaNtupleConsumer", "CutFlowTreeConsumer", "KappaElectronsConsumer", "KappaTausConsumer", "KappaTaggedJetsConsumer", "RunTimeConsumer", "PrintEventsConsumer"]
+     for unwanted in btag_eff_unwanted:
+      if unwanted in config["Consumers"]: config["Consumers"].remove(unwanted)
+
+     config["Consumers"].append("BTagEffConsumer")
+
   # pipelines - systematic shifts
   return ACU.apply_uncertainty_shift_configs('tt', config, importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2MSSM2017.syst_shifts_nom").build_config(nickname))

--- a/python/data/ArtusConfigs/Run2MSSM2017/tt.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/tt.py
@@ -188,7 +188,7 @@ def build_config(nickname):
           "HLT_DoubleMediumChargedIsoPFTau40_Trk1_TightID_eta2p1_Reg_v",
           "HLT_DoubleTightChargedIsoPFTau40_Trk1_eta2p1_Reg_v"
     ]
-  config["BTagWPs"] = ["medium"]
+
   config["InvalidateNonMatchingElectrons"] = False
   config["InvalidateNonMatchingMuons"] = False
   config["InvalidateNonMatchingTaus"] = False

--- a/python/data/ArtusConfigs/Run2MSSM2017/tt.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/tt.py
@@ -15,7 +15,9 @@ import os
 
 import HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Includes.ArtusConfigUtility as ACU
 
-def build_config(nickname):
+def build_config(nickname, **kwargs):
+  btag_eff = True if "sub_analysis" in kwargs and kwargs["sub_analysis"] == "btag-eff" else False
+
   config = jsonTools.JsonDict()
   datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
 

--- a/python/data/ArtusConfigs/Run2MSSM2017/tt.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017/tt.py
@@ -18,8 +18,7 @@ import HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Includes.ArtusConfigUtil
 def build_config(nickname):
   config = jsonTools.JsonDict()
   datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
-  
-  
+
   # define frequently used conditions
   isEmbedded = datasetsHelper.isEmbedded(nickname)
   isData = datasetsHelper.isData(nickname) and (not isEmbedded)
@@ -27,7 +26,7 @@ def build_config(nickname):
   isDY = re.search("DY.?JetsToLLM(10to50|50)", nickname)
   isWjets = re.search("W.?JetsToLNu", nickname)
   isSignal = re.search("HToTauTau",nickname)
-  
+
   ## fill config:
   # includes
   includes = [
@@ -46,7 +45,7 @@ def build_config(nickname):
   for include_file in includes:
     analysis_config_module = importlib.import_module(include_file)
     config += analysis_config_module.build_config(nickname)
-  
+
   # explicit configuration
   config["Channel"] = "TT"
   config["MinNTaus"] = 2
@@ -56,7 +55,7 @@ def build_config(nickname):
           "HLT_DoubleTightChargedIsoPFTau40_Trk1_eta2p1_Reg",
           "HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1",
     ]
-  
+
   config["TauID"] = "TauIDRecommendation13TeV"
   config["TauUseOldDMs"] = True
   config["TauLowerPtCuts"] = ["20.0"]
@@ -150,7 +149,7 @@ def build_config(nickname):
   if isEmbedded:
     config["RooWorkspace"] = "$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/scaleFactorWeights/htt_scalefactors_v17_4_embedded.root"
     config["EmbeddedWeightWorkspace"] = "$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/scaleFactorWeights/htt_scalefactors_v17_4_embedded.root"
-    config["EmbeddedWeightWorkspaceWeightNames"]=["0:muonEffTrgWeight"] 
+    config["EmbeddedWeightWorkspaceWeightNames"]=["0:muonEffTrgWeight"]
     config["EmbeddedWeightWorkspaceObjectNames"]=["0:m_sel_trg_ratio"]
     config["EmbeddedWeightWorkspaceObjectArguments"] = ["0:gt1_pt,gt1_eta,gt2_pt,gt2_eta"]
 
@@ -174,7 +173,7 @@ def build_config(nickname):
       "nobtag:$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/fakeFactorWeights/medium/tt/nobtag/fakeFactors_20170628_medium.root",
       "btag:$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/fakeFactorWeights/medium/tt/btag/fakeFactors_20170628_medium.root"
   ]
-  
+
   config["TauTauRestFrameReco"] = "collinear_approximation"
   config["TauTriggerFilterNames"] = [
           "HLT_DoubleTightChargedIsoPFTau35_Trk1_TightID_eta2p1_Reg_v:hltDoublePFTau35TrackPt1TightChargedIsolationAndTightOOSCPhotonsDz02Reg",
@@ -194,7 +193,7 @@ def build_config(nickname):
   config["InvalidateNonMatchingTaus"] = False
   config["InvalidateNonMatchingJets"] = False
   config["DirectIso"] = True
-  
+
   config["Quantities"] = importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2MSSM2017.Includes.syncQuantities").build_list()
   config["Quantities"].extend(importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Includes.weightQuantities").build_list())
   config["Quantities"].extend(importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2MSSM2017.Includes.lheWeights").build_list())
@@ -208,7 +207,7 @@ def build_config(nickname):
     config["Quantities"].extend(importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2MSSM2017.Includes.embeddedDecayModeWeightQuantities").build_list())
     config["Quantities"].extend([
           "muonEffTrgWeight"
-          ])   
+          ])
   config["OSChargeLeptons"] = True
   config["TopPtReweightingStrategy"] = "Run2"
 

--- a/python/data/ArtusConfigs/Run2MSSM2017_base.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017_base.py
@@ -16,6 +16,8 @@ def build_config(nickname, **kwargs):
   # extract the known additional parameters --analysis-channels
   analysis_channels = ['all'] if "analysis_channels" not in kwargs else kwargs["analysis_channels"]
   btag_eff = True if "sub_analysis" in kwargs and kwargs["sub_analysis"] == "btag-eff" else False
+  no_svfit = True if "no_svfit" in kwargs and kwargs["no_svfit"] else False
+
   log.debug("%s \n %25s %-30r \n %30s %-25s" % ("    Run2MSSM2017_base::", "btag_eff:", btag_eff, "analysis_channels: ", ' '.join(analysis_channels)))
 
   config = jsonTools.JsonDict()
@@ -151,11 +153,10 @@ def build_config(nickname, **kwargs):
   if "all" in analysis_channels or "mt" in analysis_channels: config["Pipelines"] += importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2MSSM2017.mt").build_config(nickname, **kwargs)
   if "all" in analysis_channels or "tt" in analysis_channels: config["Pipelines"] += importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2MSSM2017.tt").build_config(nickname, **kwargs)
 
-  if btag_eff:
+  if btag_eff or no_svfit:  # disable SVFit
     for pipeline_config in config["Pipelines"].values():
-      if True:  # disable SVFit
-          pipeline_config["Quantities"] = list(set(pipeline_config["Quantities"]) - set(["m_sv", "pt_sv", "eta_sv", "phi_sv"]))
-          if "producer:SvfitProducer" in pipeline_config["Processors"]:
-            pipeline_config["Processors"].remove("producer:SvfitProducer")
+      pipeline_config["Quantities"] = list(set(pipeline_config["Quantities"]) - set(["m_sv", "pt_sv", "eta_sv", "phi_sv"]))
+      if "producer:SvfitProducer" in pipeline_config["Processors"]:
+        pipeline_config["Processors"].remove("producer:SvfitProducer")
 
   return config

--- a/python/data/ArtusConfigs/Run2MSSM2017_base.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017_base.py
@@ -25,7 +25,6 @@ def build_config(nickname, **kwargs):
   isSUSYggH = re.search("SUSYGluGluToHToTauTau", nickname)
   isSignal = re.search("HToTauTau",nickname)
 
-
   ## fill config:
   # includes
   includes = [

--- a/python/data/ArtusConfigs/Run2MSSM2017_base.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017_base.py
@@ -24,8 +24,8 @@ def build_config(nickname, **kwargs):
   isWjets = re.search("W.?JetsToLNu", nickname)
   isSUSYggH = re.search("SUSYGluGluToHToTauTau", nickname)
   isSignal = re.search("HToTauTau",nickname)
-  
-  
+
+
   ## fill config:
   # includes
   includes = [
@@ -36,13 +36,13 @@ def build_config(nickname, **kwargs):
   for include_file in includes:
     analysis_config_module = importlib.import_module(include_file)
     config += analysis_config_module.build_config(nickname)
-  
+
   # explicit configuration
   config["SkipEvents"] = 0
   config["EventCount"] = -1
   config["Year"] = 2017
   config["InputIsData"] = isData
-  
+
   if isSUSYggH:
     config["HiggsBosonMass"] = re.search("SUSYGluGluToHToTauTauM(\d+)_", nickname).groups()[0] #extracts generator mass from nickname
     config["NLOweightsRooWorkspace"] = "$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/NLOWeights/higgs_pt_v2_mssm_mode.root"
@@ -66,13 +66,13 @@ def build_config(nickname, **kwargs):
   config["BosonPdgIds"] = [0]
   for key, pdgids in BosonPdgIds.items():
     if re.search(key, nickname): config["BosonPdgIds"] = pdgids
-  
+
   config["BosonStatuses"] = [62]
   config["ChooseMvaMet"] = False
   config["UseUWGenMatching"] = True
   config["UpdateMetWithCorrectedLeptons"] = True
   config["UpdateMetWithCorrectedLeptonsFromSignalOnly"] = True
-  
+
   config["MetFilterToFlag"] = [
         "Flag_HBHENoiseFilter",
         "Flag_HBHENoiseIsoFilter",
@@ -87,9 +87,9 @@ def build_config(nickname, **kwargs):
     config["MetFilterToFlag"].extend((
         "Flag_eeBadScFilter",
     ))
-  
+
   config["OutputPath"] = "output.root"
-  
+
   config["Processors"] = []
   #config["Processors"].append("filter:RunLumiEventFilter")
   if isData or isEmbedded:             config["Processors"].append( "filter:JsonFilter")
@@ -98,7 +98,7 @@ def build_config(nickname, **kwargs):
   config["Processors"].append(                                      "producer:MetFilterFlagProducer")
   if not isData:
 
-    if not isEmbedded:                 
+    if not isEmbedded:
       config["Processors"].append( "producer:PUWeightProducer")
       config["Processors"].extend((                                   "producer:CrossSectionWeightProducer",
                                                                     "producer:NumberGeneratedEventsWeightProducer"))
@@ -126,19 +126,18 @@ def build_config(nickname, **kwargs):
   config["MetShiftCorrectorFile"] = "$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/recoilMet/PFMEtSys_2016.root"
   config["MvaMetRecoilCorrectorFile"] = "$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/recoilMet/MvaMET_2016BCD.root"
   config["MetCorrectionMethod"] = "none"
-  
+
   if isData or isEmbedded:
     if   re.search("Run2017|Embedding2017", nickname):      config["JsonFiles"] = ["$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/json/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON_v1.txt"]
     elif re.search("Run2016|Embedding2016", nickname):      config["JsonFiles"] = ["$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"]
     elif re.search("Run2015(C|D)|Embedding2015", nickname): config["JsonFiles"] = ["$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/json/Cert_13TeV_16Dec2015ReReco_Collisions15_25ns_JSON_v2.txt"]
     elif re.search("Run2015B", nickname):                   config["JsonFiles"] = ["$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/json/Cert_13TeV_16Dec2015ReReco_Collisions15_50ns_JSON_v2.txt"]
-    
+
   config["SimpleMuTauFakeRateWeightLoose"] = [1.06, 1.02, 1.10, 1.03, 1.94]
   config["SimpleMuTauFakeRateWeightTight"] = [1.17, 1.29, 1.14, 0.93, 1.61]
   config["SimpleEleTauFakeRateWeightVLoose"] = [1.09, 1.19]
   config["SimpleEleTauFakeRateWeightTight"] = [1.80, 1.53]
 
-  
   # pipelines - channels including systematic shifts
   config["Pipelines"] = jsonTools.JsonDict()
   #config["Pipelines"] += importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2MSSM2017.ee").build_config(nickname)

--- a/python/data/ArtusConfigs/Run2MSSM2017_base.py
+++ b/python/data/ArtusConfigs/Run2MSSM2017_base.py
@@ -12,7 +12,7 @@ import Kappa.Skimming.datasetsHelperTwopz as datasetsHelperTwopz
 import importlib
 import os
 
-def build_config(nickname):
+def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
 

--- a/python/data/ArtusConfigs/Run2MSSM_base.py
+++ b/python/data/ArtusConfigs/Run2MSSM_base.py
@@ -12,7 +12,7 @@ import Kappa.Skimming.datasetsHelperTwopz as datasetsHelperTwopz
 import importlib
 import os
 
-def build_config(nickname):
+def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
   

--- a/python/data/ArtusConfigs/Run2MSSM_base.py
+++ b/python/data/ArtusConfigs/Run2MSSM_base.py
@@ -15,16 +15,16 @@ import os
 def build_config(nickname, **kwargs):
   config = jsonTools.JsonDict()
   datasetsHelper = datasetsHelperTwopz.datasetsHelperTwopz(os.path.expandvars("$CMSSW_BASE/src/Kappa/Skimming/data/datasets.json"))
-  
-  
+
+
   # define frequently used conditions
   isEmbedded = datasetsHelper.isEmbedded(nickname)
   isData = datasetsHelper.isData(nickname) and (not isEmbedded)
   isTTbar = re.search("TT(To|_|Jets)", nickname)
   isDY = re.search("DY.?JetsToLLM(50|150)", nickname)
   isWjets = re.search("W.?JetsToLNu", nickname)
-  
-  
+
+
   ## fill config:
   # includes
   includes = [
@@ -35,12 +35,12 @@ def build_config(nickname, **kwargs):
   for include_file in includes:
     analysis_config_module = importlib.import_module(include_file)
     config += analysis_config_module.build_config(nickname)
-  
+
   # explicit configuration
   config["SkipEvents"] = 0
   config["EventCount"] = -1
   config["InputIsData"] = isData
-  
+
   BosonPdgIds = {
       "DY.?JetsToLL|EWKZ2Jets|Embedding(2016|MC)" : [
         23
@@ -60,7 +60,7 @@ def build_config(nickname, **kwargs):
   config["BosonPdgIds"] = [0]
   for key, pdgids in BosonPdgIds.items():
     if re.search(key, nickname): config["BosonPdgIds"] = pdgids
-  
+
   config["BosonStatuses"] = [62]
   config["ChooseMvaMet"] = False
   config["DeltaRMatchingRecoElectronsGenParticle"] = 0.2
@@ -79,7 +79,7 @@ def build_config(nickname, **kwargs):
   config["MatchAllMuonsGenTau"] = "true"
   config["MatchAllTausGenTau"] = "true"
   config["UpdateMetWithCorrectedLeptons"] = "true"
-  
+
   config["MetFilter"] = [
         "Flag_HBHENoiseFilter",
         "Flag_HBHENoiseIsoFilter",
@@ -100,9 +100,9 @@ def build_config(nickname, **kwargs):
         "!Flag_badGlobalMuonTaggerMAOD",
         "!Flag_cloneGlobalMuonTaggerMAOD"
     ))
-  
+
   config["OutputPath"] = "output.root"
-  
+
   config["Processors"] = []
   #config["Processors"].append("filter:RunLumiEventFilter")
   if not isEmbedded:                   config["Processors"].append( "filter:MetFilter")
@@ -141,12 +141,12 @@ def build_config(nickname, **kwargs):
   config["MetCorrectionMethod"] = "meanResolution"
   config["BTagScaleFactorFile"] = "$CMSSW_BASE/src/Artus/KappaAnalysis/data/CSVv2_moriond17_BtoH.csv"
   config["BTagEfficiencyFile"] = "$CMSSW_BASE/src/Artus/KappaAnalysis/data/tagging_efficiencies_moriond2017.root"
-  
+
   if isData or isEmbedded:
     if   re.search("Run2016|Embedding2016", nickname):      config["JsonFiles"] = ["$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/json/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"]
     elif re.search("Run2015(C|D)|Embedding2015", nickname): config["JsonFiles"] = ["$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/json/Cert_13TeV_16Dec2015ReReco_Collisions15_25ns_JSON_v2.txt"]
     elif re.search("Run2015B", nickname):                   config["JsonFiles"] = ["$CMSSW_BASE/src/HiggsAnalysis/KITHiggsToTauTau/data/root/json/Cert_13TeV_16Dec2015ReReco_Collisions15_50ns_JSON_v2.txt"]
-    
+
   if re.search("Fall15MiniAODv2", nickname):
     config["SimpleMuTauFakeRateWeightLoose"] = [1.0, 1.0, 1.0, 1.0, 1.0]
     config["SimpleMuTauFakeRateWeightTight"] = [1.0, 1.0, 1.0, 1.0, 1.0]
@@ -158,7 +158,7 @@ def build_config(nickname, **kwargs):
     config["SimpleEleTauFakeRateWeightVLoose"] = [1.21, 1.38]
     config["SimpleEleTauFakeRateWeightTight"] = [1.40, 1.90]
 
-  
+
   # pipelines - channels including systematic shifts
   config["Pipelines"] = jsonTools.JsonDict()
   #config["Pipelines"] += importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2MSSM.ee").build_config(nickname)
@@ -167,6 +167,6 @@ def build_config(nickname, **kwargs):
   config["Pipelines"] += importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2MSSM.mm").build_config(nickname)
   config["Pipelines"] += importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2MSSM.mt").build_config(nickname)
   config["Pipelines"] += importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2MSSM.tt").build_config(nickname)
-  
-  
+
+
   return config

--- a/python/higgstotautauanalysiswrapper.py
+++ b/python/higgstotautauanalysiswrapper.py
@@ -245,6 +245,8 @@ class HiggsToTauTauAnalysisWrapper():
 		                                 help="Open output file in ROOT TBrowser after completion.")
 		runningOptionsGroup.add_argument("-b", "--batch", default=False, const="naf", nargs="?",
 		                                 help="Run with grid-control. Optionally select backend. [Default: %(default)s]")
+		runningOptionsGroup.add_argument("--batch-jobs-debug", default=False, action="store_true",
+		                                 help="Option enables more printouts for single jobs for example: printing the artus config to stdout.")  # TODO: this needs to be redirected in separate file to transfer as output
 		runningOptionsGroup.add_argument("--pilot-job-files", "--pilot-jobs", default=None, const=1, type=int, nargs="?",
 		                                 help="Number of files per sample to be submitted as pilot jobs. [Default: all/1]")
 		runningOptionsGroup.add_argument("--files-per-job", type=int, default=15,
@@ -407,7 +409,7 @@ class HiggsToTauTauAnalysisWrapper():
 		self._configFilename = filepath
 		self._config.save(self._configFilename, indent=4)
 
-		if self._args.batch:
+		if self._args.batch and self._args.batch_jobs_debug:
 			import pprint
 			pp = pprint.PrettyPrinter(indent=4)
 			pp.pprint(self._config)
@@ -588,7 +590,9 @@ class HiggsToTauTauAnalysisWrapper():
 		epilogArguments += (" --analysis-channels %s " % " ".join(self._args.analysis_channels))
 		if self._args.no_svfit:
 			epilogArguments += (" --no-svfit ")
-		print "single job arguments epilogArguments:", epilogArguments
+
+		if self._args.batch_jobs_debug:
+			print "single job arguments epilogArguments:", epilogArguments
 
 		sepath = "se path = " + (self._args.se_path if self._args.se_path else sepathRaw)
 		workdir = "workdir = " + os.path.join(localProjectPath, "workdir")

--- a/python/higgstotautauanalysiswrapper.py
+++ b/python/higgstotautauanalysiswrapper.py
@@ -26,7 +26,7 @@ import ROOT
 
 class HiggsToTauTauAnalysisWrapper():
 	def __init__(self, executable=None, userArgParsers=None):
-		
+
 		self._config = jsonTools.JsonDict()
 		self._executable = "HiggsToTauTauAnalysis"
 
@@ -36,17 +36,17 @@ class HiggsToTauTauAnalysisWrapper():
 		#Parse command line arguments and return dict
 		self._args = self._parser.parse_args()
 		logger.initLogger(self._args)
-		
+
 		self._date_now = datetime.now().strftime("%Y-%m-%d_%H-%M")
-			
+
 		self.tmp_directory_remote_files = None
-		
+
 		self._gridControlInputFiles = {}
-		
+
 	def run(self):
-		
+
 		exitCode = 0
-		
+
 		#Set input filenames
 		self._config["InputFiles"] = [] #overwrite settings from config file by command line
 		inputFileList = self._args.input_files
@@ -62,7 +62,7 @@ class HiggsToTauTauAnalysisWrapper():
 			self._config["InputFiles"] = [""]
 		elif not self._args.fast is None:
 			self._config["InputFiles"] = self._config["InputFiles"][:min(len(self._config["InputFiles"]), self._args.fast)]
-		
+
 		#run on batch system via grid-control or locally
 		if self._args.batch:
 			# artus config not needed at this stage, it will be generated when this is run on the batch node again
@@ -93,7 +93,7 @@ class HiggsToTauTauAnalysisWrapper():
 			self.saveConfig(self._args.save_config)
 			if self._args.print_config:
 				log.info(self._config)
-			
+
 			# set LD_LIBRARY_PATH
 			if not self._args.ld_library_paths is None:
 				for path in self._args.ld_library_paths:
@@ -104,17 +104,17 @@ class HiggsToTauTauAnalysisWrapper():
 			if self._args.print_envvars:
 				for envvar in self._args.print_envvars:
 					log.info("$%s = %s" % (envvar, os.environ.get(envvar, "")))
-			
+
 			# if desired, run artus locally or measure performance
 			if self._args.profile:
 				exitCode = self.measurePerformance(self._args.profile,self._args.profile_options)
 			elif not self._args.no_run:
 				exitCode = self.callExecutable()
-			
+
 			# clean up
 			if (not self.tmp_directory_remote_files is None):
 				shutil.rmtree(self.tmp_directory_remote_files)
-			
+
 			### comparison to configs generated in the former artusWrapper (to be removed when configs are successfully; Also remove -ii option
 			if not self._args.input_files_comp == None:
 				config2 = jsonTools.JsonDict(self._args.input_files_comp)
@@ -160,20 +160,20 @@ class HiggsToTauTauAnalysisWrapper():
 				print "compare baseline"
 				print config3.diff(config2)
 			### comparison end
-		
+
 		if exitCode < 256:
 			return exitCode
 		else:
 			return 1 # Artus sometimes returns exit codes >255 that are not supported
-		
+
 	def _initArgumentParser(self, userArgParsers=None):
-		
+
 		if userArgParsers is None:
 			userArgParsers = []
-		
+
 		self._parser = argparse.ArgumentParser(parents=[logger.loggingParser] + userArgParsers, fromfile_prefix_chars="@",
 		                                       description="Wrapper for Artus executables. Configs are to be set internally.")
-		
+
 		self._parser.add_argument("-x", "--executable", help="Artus executable. [Default: %(default)s]", default=os.path.basename(sys.argv[0]))
 		self._parser.add_argument("-a", "--analysis", required=True, help="Analysis nick [SM, MSSM] or import path ('HiggsAnalysis.KITHiggsToTauTau. ...' or 'HiggsAnalysis/KITHiggsToTauTau/python/ ... .py') of the config module.")
 
@@ -188,7 +188,7 @@ class HiggsToTauTauAnalysisWrapper():
 		                              help="Work directory base. [Default: %(default)s]")
 		fileOptionsGroup.add_argument("-n", "--project-name", default="analysis",
 		                              help="Name for this Artus project specifies the name of the work subdirectory.")
-		
+
 		configOptionsGroup = self._parser.add_argument_group("Config options")
 		#configOptionsGroup.add_argument("-c", "--base-configs", nargs="+", required=False, default={},
 		#                                help="JSON base configurations. All configs are merged.")
@@ -198,7 +198,7 @@ class HiggsToTauTauAnalysisWrapper():
 		#                                help="JSON pipeline configurations. Single entries (whitespace separated strings) are first merged. Then all entries are expanded to get all possible combinations. For each expansion, this option has to be used. Afterwards, all results are merged into the JSON base config.")
 		configOptionsGroup.add_argument("--nick", default="auto",
 		                                help="Kappa nickname name that can be used for switch between sample-dependent settings.")
-		
+
 		configOptionsGroup.add_argument("--disable-repo-versions", default=False, action="store_true",
 		                                help="Add repository versions to the JSON config.")
 		configOptionsGroup.add_argument("--repo-scan-base-dirs", nargs="+", required=False, default="$CMSSW_BASE/src/",
@@ -259,8 +259,8 @@ class HiggsToTauTauAnalysisWrapper():
 		                                 help="Write logfile in batch mode directly to SE. Does not work with remote batch system")
 		runningOptionsGroup.add_argument("--partition-lfn-modifier", default = None,
 		                                 help="Forces a certain access to input files. See base conf for corresponding dictionary")
-		
-	
+
+
 	def import_analysis_configs(self):
 		# define known analysis keys here
 		analysis_configs_dict = {
@@ -322,7 +322,7 @@ class HiggsToTauTauAnalysisWrapper():
 				self.setInputFilenames(txtFileContent)
 			else:
 				log.warning("Found file in input search path that is not further considered: " + entry + "\n")
-	
+
 	def readDbsFile(self, path):
 		dbsInput = {}
 		with open(path, "r") as dbsfile:
@@ -381,7 +381,7 @@ class HiggsToTauTauAnalysisWrapper():
 			length += len(item)
 		log.info("Final dbs consists of %i files" %length)
 		return dbs
-	
+
 	def extractNickname(self, string): ###could be inherited from artusWrapper!
 		filename = os.path.basename(string)
 		nickname = filename[filename.find("_")+1:filename.rfind("_")]
@@ -389,7 +389,7 @@ class HiggsToTauTauAnalysisWrapper():
 		if nickname == "":
 			nickname = self._args.nick
 		return nickname
-	
+
 	def saveConfig(self, filepath=None): ###could be inherited from artusWrapper!
 		"""Save Config to File"""
 		if not filepath:
@@ -408,7 +408,7 @@ class HiggsToTauTauAnalysisWrapper():
 					if not self._args.batch:
 						log.warning("Input files do have different nicknames, which could cause errors.")
 		return nickname
-	
+
 	def useLocalCopiesOfRemoteFiles(self, remote_identifiers=None):
 		if remote_identifiers is None:
 			remote_identifiers = ["dcap", "root"]
@@ -447,7 +447,7 @@ class HiggsToTauTauAnalysisWrapper():
 			for repoScanDir in repoScanDirs:
 				popenCout, popenCerr = subprocess.Popen(currentRevisionCommand.split(), stdout=subprocess.PIPE, cwd=repoScanDir).communicate()
 				self._config[repoScanDir] = popenCout.replace("\n", "")
-	
+
 	def readInExternals(self):
 		if not "NumberGeneratedEvents" in self._config or (int(self._config["NumberGeneratedEvents"]) < 0):
 			from Kappa.Skimming.registerDatasetHelper import get_n_generated_events_from_nick
@@ -475,7 +475,7 @@ class HiggsToTauTauAnalysisWrapper():
 			generator_weight = get_generator_weight(self._config["Nickname"])
 			if(generator_weight > 0 and generator_weight <= 1.0):
 				self._config["GeneratorWeight"] = generator_weight
-	
+
 	def measurePerformance(self, profTool, profOpt): ###could be inherited from artusWrapper!
 		"""run Artus with profiler"""
 
@@ -513,9 +513,9 @@ class HiggsToTauTauAnalysisWrapper():
 		# os.system("rm " + self._configFilename)
 
 		return exitCode
-	
+
 	def sendToBatchSystem(self):
-		
+
 		#set project paths
 		remote_se = False
 		projectPath = os.path.join(os.path.expandvars(self._args.work), self._date_now+"_"+self._args.project_name)
@@ -523,12 +523,12 @@ class HiggsToTauTauAnalysisWrapper():
 		if projectPath.startswith("srm://"):
 			remote_se = True
 			localProjectPath = os.path.join(os.path.expandvars(self._parser.get_default("work")), self._date_now+"_"+self._args.project_name)
-			
+
 		#create folders
 		if not os.path.exists(localProjectPath):
 			os.makedirs(localProjectPath)
 			os.makedirs(os.path.join(localProjectPath, "output"))
-			
+
 		# write dbs file
 		dbsFileContent = tools.write_dbsfile(self._gridControlInputFiles, max_files_per_nick=self._args.pilot_job_files)
 
@@ -625,6 +625,6 @@ class HiggsToTauTauAnalysisWrapper():
 			#log.info(self._configFilename)
 
 		return exitCode
-	
+
 	def modify_replacing_dict(self):
 		self.replacingDict["areafiles"] += " auxiliaries/mva_weights"

--- a/python/higgstotautauanalysiswrapper.py
+++ b/python/higgstotautauanalysiswrapper.py
@@ -581,7 +581,14 @@ class HiggsToTauTauAnalysisWrapper():
 		if self._args.copy_remote_files:
 			epilogArguments += "--copy-remote-files "
 		if not self._args.ld_library_paths is None:
-			epilogArguments += ("--ld-library-paths %s" % " ".join(self._args.ld_library_paths))
+			epilogArguments += ("--ld-library-paths %s " % " ".join(self._args.ld_library_paths))
+
+		if self._args.sub_analysis != "":
+			epilogArguments += (" --sub-analysis %s " % " ".join(self._args.sub_analysis))
+		epilogArguments += (" --analysis-channels %s " % " ".join(self._args.analysis_channels))
+		if self._args.no_svfit:
+			epilogArguments += (" --no-svfit ")
+		print "single job arguments epilogArguments:", epilogArguments
 
 		sepath = "se path = " + (self._args.se_path if self._args.se_path else sepathRaw)
 		workdir = "workdir = " + os.path.join(localProjectPath, "workdir")

--- a/python/higgstotautauanalysiswrapper.py
+++ b/python/higgstotautauanalysiswrapper.py
@@ -231,7 +231,7 @@ class HiggsToTauTauAnalysisWrapper():
 		                                help="Path to grid-control configs to include in the base config.")
 
 		runningOptionsGroup = self._parser.add_argument_group("Running options")
-		runningOptionsGroup.add_argument("--no-run", default=False, action="store_true",
+		runningOptionsGroup.add_argument("--no-run", "--dry", "--dry-run", default=False, action="store_true",
 		                                 help="Exit before running Artus to only check the configs.")
 		runningOptionsGroup.add_argument("--copy-remote-files", default=False, action="store_true",
 		                                 help="Copy remote files first to avoid too many open connections.")

--- a/python/higgstotautauanalysiswrapper.py
+++ b/python/higgstotautauanalysiswrapper.py
@@ -406,6 +406,12 @@ class HiggsToTauTauAnalysisWrapper():
 			filepath = os.path.join(tempfile.gettempdir(), basename)
 		self._configFilename = filepath
 		self._config.save(self._configFilename, indent=4)
+
+		if self._args.batch:
+			import pprint
+			pp = pprint.PrettyPrinter(indent=4)
+			pp.pprint(self._config)
+
 		log.info("Saved JSON config \"%s\" for temporary usage." % self._configFilename)
 
 	def determineNickname(self, nickname):

--- a/python/higgstotautauanalysiswrapper.py
+++ b/python/higgstotautauanalysiswrapper.py
@@ -176,8 +176,10 @@ class HiggsToTauTauAnalysisWrapper():
 
 		self._parser.add_argument("-x", "--executable", help="Artus executable. [Default: %(default)s]", default=os.path.basename(sys.argv[0]))
 		self._parser.add_argument("-a", "--analysis", required=True, help="Analysis nick [SM, MSSM] or import path ('HiggsAnalysis.KITHiggsToTauTau. ...' or 'HiggsAnalysis/KITHiggsToTauTau/python/ ... .py') of the config module.")
+
 		self._parser.add_argument("--sub-analysis", default='', action='store', choices=['btag-eff'], help="Keys to run a sub-analysis on top of base analyseis. Example: btag-egg Option to simplify the configs in order to estimate the efficiencies faster. [Default: %(default)s]")
 		self._parser.add_argument("--analysis-channels", default='all', nargs='+', type=str, choices=['all', 'mt', 'tt', 'et', 'ee', 'em', 'mm'], help="List of channels processed from the analysi. [Default: %(default)s]")
+		self._parser.add_argument("--no-svfit", default=False, action="store_true", help="Disable SVfit. Default: %(default)s]")
 
 		fileOptionsGroup = self._parser.add_argument_group("File options")
 		fileOptionsGroup.add_argument("-i", "--input-files", nargs="+", required=True,
@@ -286,7 +288,12 @@ class HiggsToTauTauAnalysisWrapper():
 		log.debug("Prepare config for \""+nickname+"\" sample...")
 		self._config["Nickname"] = nickname
 		# import configs
-		self._config += analysis_config_module.build_config(nickname, sub_analysis=self._args.sub_analysis, analysis_channels=self._args.analysis_channels)
+		self._config += analysis_config_module.build_config(
+			nickname,
+			sub_analysis=self._args.sub_analysis,
+			analysis_channels=self._args.analysis_channels,
+			no_svfit=self._args.no_svfit,
+		)
 
 	def setInputFilenames(self, filelist, alreadyInGridControl = False): ###could be inherited from artusWrapper!
 		#if (not (isinstance(self._config["InputFiles"], list)) and not isinstance(self._config["InputFiles"], basestring)):

--- a/python/higgstotautauanalysiswrapper.py
+++ b/python/higgstotautauanalysiswrapper.py
@@ -176,6 +176,8 @@ class HiggsToTauTauAnalysisWrapper():
 
 		self._parser.add_argument("-x", "--executable", help="Artus executable. [Default: %(default)s]", default=os.path.basename(sys.argv[0]))
 		self._parser.add_argument("-a", "--analysis", required=True, help="Analysis nick [SM, MSSM] or import path ('HiggsAnalysis.KITHiggsToTauTau. ...' or 'HiggsAnalysis/KITHiggsToTauTau/python/ ... .py') of the config module.")
+		self._parser.add_argument("--sub-analysis", default='', action='store', choices=['btag-eff'], help="Keys to run a sub-analysis on top of base analyseis. Example: btag-egg Option to simplify the configs in order to estimate the efficiencies faster. [Default: %(default)s]")
+		self._parser.add_argument("--analysis-channels", default='all', nargs='+', type=str, choices=['all', 'mt', 'tt', 'et', 'ee', 'em', 'mm'], help="List of channels processed from the analysi. [Default: %(default)s]")
 
 		fileOptionsGroup = self._parser.add_argument_group("File options")
 		fileOptionsGroup.add_argument("-i", "--input-files", nargs="+", required=True,
@@ -284,8 +286,8 @@ class HiggsToTauTauAnalysisWrapper():
 		log.debug("Prepare config for \""+nickname+"\" sample...")
 		self._config["Nickname"] = nickname
 		# import configs
-		self._config += analysis_config_module.build_config(nickname)
-	
+		self._config += analysis_config_module.build_config(nickname, sub_analysis=self._args.sub_analysis, analysis_channels=self._args.analysis_channels)
+
 	def setInputFilenames(self, filelist, alreadyInGridControl = False): ###could be inherited from artusWrapper!
 		#if (not (isinstance(self._config["InputFiles"], list)) and not isinstance(self._config["InputFiles"], basestring)):
 		self._config["InputFiles"] = []

--- a/python/higgstotautauanalysiswrapper.py
+++ b/python/higgstotautauanalysiswrapper.py
@@ -178,7 +178,7 @@ class HiggsToTauTauAnalysisWrapper():
 		self._parser.add_argument("-a", "--analysis", required=True, help="Analysis nick [SM, MSSM] or import path ('HiggsAnalysis.KITHiggsToTauTau. ...' or 'HiggsAnalysis/KITHiggsToTauTau/python/ ... .py') of the config module.")
 
 		self._parser.add_argument("--sub-analysis", default='', action='store', choices=['btag-eff'], help="Keys to run a sub-analysis on top of base analyseis. Example: btag-egg Option to simplify the configs in order to estimate the efficiencies faster. [Default: %(default)s]")
-		self._parser.add_argument("--analysis-channels", default='all', nargs='+', type=str, choices=['all', 'mt', 'tt', 'et', 'ee', 'em', 'mm'], help="List of channels processed from the analysi. [Default: %(default)s]")
+		self._parser.add_argument("--analysis-channels", default=['all'], nargs='+', type=str, choices=['all', 'mt', 'tt', 'et', 'ee', 'em', 'mm'], help="List of channels processed from the analysis. [Default: %(default)s]")
 		self._parser.add_argument("--no-svfit", default=False, action="store_true", help="Disable SVfit. Default: %(default)s]")
 
 		fileOptionsGroup = self._parser.add_argument_group("File options")

--- a/src/Consumers/BTagEffConsumer.cc
+++ b/src/Consumers/BTagEffConsumer.cc
@@ -1,83 +1,84 @@
 #include "HiggsAnalysis/KITHiggsToTauTau/interface/Consumers/BTagEffConsumer.h"
 
-//#include "Kappa/DataFormats/interface/Kappa.h"
-
-
 void BTagEffConsumer::Init(setting_type const& settings)
 {
-	ConsumerBase<HttTypes>::Init(settings);
-	//Histograms initialization for different muons and Pt Flow per DeltaR.
-	//Format of the histograms: PtFlow per DeltaR on y-axis and DeltaR on x-axis.
-	//nDeltaRBins = settings.GetDeltaRBinning();
-	//DeltaRMax = settings.GetDeltaRMaximum();
+    ConsumerBase<HttTypes>::Init(settings);
+    //Histograms initialization for different muons and Pt Flow per DeltaR.
+    //Format of the histograms: PtFlow per DeltaR on y-axis and DeltaR on x-axis.
+    //nDeltaRBins = settings.GetDeltaRBinning();
+    //DeltaRMax = settings.GetDeltaRMaximum();
 
-	//btag efficiency measurement -> possible to get binning by cfgs settings
-	int  ptNBins = 20;
-	double ptBins[ptNBins];
-	ptBins[0] = 20, ptBins[1] = 30, ptBins[2] = 40, ptBins[3] = 50, ptBins[4] = 60, ptBins[5] = 70, ptBins[6] = 80, ptBins[7] = 100, ptBins[8] = 120;
-	ptBins[9] = 160, ptBins[10] = 210, ptBins[11] = 260, ptBins[12] = 320, ptBins[13] = 400, ptBins[14] = 500, ptBins[15] = 600, ptBins[16] = 700, ptBins[17] = 800, ptBins[18] = 900, ptBins[19] = 1000;
-	int etaNBins = 5;
-	double etaBins[etaNBins];
-	etaBins[0] = 0.0, etaBins[1] = 0.9, etaBins[2] = 1.2, etaBins[3] = 2.1, etaBins[4] = 2.4;//, etaBins[4] =  5.0;
-	m_BTaggingEff_Denom_b   = new TH2D("BTaggingEff_Denom_b", ";p_{T} [GeV];#eta", ptNBins-1, ptBins, etaNBins-1, etaBins);
-	m_BTaggingEff_Denom_c   = new TH2D("BTaggingEff_Denom_c", ";p_{T} [GeV];#eta", ptNBins-1, ptBins, etaNBins-1, etaBins);
-	m_BTaggingEff_Denom_udsg = new TH2D("BTaggingEff_Denom_udsg", ";p_{T} [GeV];#eta", ptNBins-1, ptBins, etaNBins-1, etaBins);
-	m_BTaggingEff_Num_b  = new TH2D("bTaggingEff_Num_b", ";p_{T} [GeV];#eta", ptNBins-1, ptBins, etaNBins-1, etaBins);
-	m_BTaggingEff_Num_c  = new TH2D("bTaggingEff_Num_c", ";p_{T} [GeV];#eta", ptNBins-1, ptBins, etaNBins-1, etaBins);
-	m_BTaggingEff_Num_udsg  = new TH2D("bTaggingEff_Num_udsg", ";p_{T} [GeV];#eta", ptNBins-1, ptBins, etaNBins-1, etaBins);
+    //btag efficiency measurement -> possible to get binning by cfgs settings
+    int  ptNBins = 20;
+    double ptBins[ptNBins];
+    ptBins[0] = 20, ptBins[1] = 30, ptBins[2] = 40, ptBins[3] = 50, ptBins[4] = 60, ptBins[5] = 70, ptBins[6] = 80, ptBins[7] = 100, ptBins[8] = 120;
+    ptBins[9] = 160, ptBins[10] = 210, ptBins[11] = 260, ptBins[12] = 320, ptBins[13] = 400, ptBins[14] = 500, ptBins[15] = 600, ptBins[16] = 700, ptBins[17] = 800, ptBins[18] = 900, ptBins[19] = 1000;
+    int etaNBins = 5;
+    double etaBins[etaNBins];
+    etaBins[0] = 0.0, etaBins[1] = 0.9, etaBins[2] = 1.2, etaBins[3] = 2.1, etaBins[4] = 2.4;//, etaBins[4] =  5.0;
+    m_BTaggingEff_Denom_b   = new TH2D("BTaggingEff_Denom_b", ";p_{T} [GeV];#eta", ptNBins-1, ptBins, etaNBins-1, etaBins);
+    m_BTaggingEff_Denom_c   = new TH2D("BTaggingEff_Denom_c", ";p_{T} [GeV];#eta", ptNBins-1, ptBins, etaNBins-1, etaBins);
+    m_BTaggingEff_Denom_udsg = new TH2D("BTaggingEff_Denom_udsg", ";p_{T} [GeV];#eta", ptNBins-1, ptBins, etaNBins-1, etaBins);
+    m_BTaggingEff_Num_b  = new TH2D("bTaggingEff_Num_b", ";p_{T} [GeV];#eta", ptNBins-1, ptBins, etaNBins-1, etaBins);
+    m_BTaggingEff_Num_c  = new TH2D("bTaggingEff_Num_c", ";p_{T} [GeV];#eta", ptNBins-1, ptBins, etaNBins-1, etaBins);
+    m_BTaggingEff_Num_udsg  = new TH2D("bTaggingEff_Num_udsg", ";p_{T} [GeV];#eta", ptNBins-1, ptBins, etaNBins-1, etaBins);
 }
-
-//void ValidBTaggedJetsProducer::Produce(KappaEvent const& event, KappaProduct& product,
-//                                       KappaSettings const& settings) const
-//{
 
 void BTagEffConsumer::ProcessFilteredEvent(event_type const& event, product_type const& product, setting_type const& settings)
 {
-  assert(event.m_jetMetadata);
+    assert(event.m_jetMetadata);
 
-  //for(std::vector<KMuon*>::const_iterator validMuon = product.m_validMuons.begin();validMuon!=product.m_validMuons.end();++validMuon)
-  //for (std::vector<KBasicJet*>::cons_iterator jet = product.m_validJets.begin(); jet != product.m_validJets.end(); ++jet)
-  std::map<std::string, std::vector<float>> bTagWorkingPoints = Utility::ParseMapTypes<std::string,float>(Utility::ParseVectorToMap(settings.GetBTaggerWorkingPoints()));
-  float bTaggingWorkingPoint = bTagWorkingPoints.at(settings.GetBTagWPs().at(0)).at(0);
-  for (auto jet = product.m_validJets.begin(); jet != product.m_validJets.end(); ++jet)
+    //for(std::vector<KMuon*>::const_iterator validMuon = product.m_validMuons.begin();validMuon!=product.m_validMuons.end();++validMuon)
+    //for (std::vector<KBasicJet*>::cons_iterator jet = product.m_validJets.begin(); jet != product.m_validJets.end(); ++jet)
+    std::map<std::string, std::vector<float>> bTagWorkingPoints = Utility::ParseMapTypes<std::string, float>(
+        Utility::ParseVectorToMap(settings.GetBTaggerWorkingPoints())
+    );
+
+    float bTaggingWorkingPoint = bTagWorkingPoints.at(settings.GetBTagWPs().at(0)).at(0);
+
+    for (auto jet = product.m_validJets.begin(); jet != product.m_validJets.end(); ++jet)
     {
-      KJet* tjet = static_cast<KJet*>(*jet);
-      float combinedSecondaryVertex = tjet->getTag(settings.GetBTaggedJetCombinedSecondaryVertexName(), event.m_jetMetadata);
-      
-	      int jetflavor = tjet->hadronFlavour;
-	      if(jetflavor==5){
-		m_BTaggingEff_Denom_b->Fill(tjet->p4.pt(), std::fabs(tjet->p4.eta()));
-		if(combinedSecondaryVertex>bTaggingWorkingPoint){
-		  m_BTaggingEff_Num_b->Fill(tjet->p4.pt(), std::fabs(tjet->p4.eta()));			    
-		}
-	      }
-	      else if(jetflavor==4){
-		m_BTaggingEff_Denom_c->Fill(tjet->p4.pt(), std::fabs(tjet->p4.eta()));
-		if(combinedSecondaryVertex>bTaggingWorkingPoint){
-		  m_BTaggingEff_Num_c->Fill(tjet->p4.pt(), std::fabs(tjet->p4.eta()));			   
-		}
-	      }
-	      else{
-		m_BTaggingEff_Denom_udsg->Fill(tjet->p4.pt(), std::fabs(tjet->p4.eta()));
-		if(combinedSecondaryVertex>bTaggingWorkingPoint){
-		  m_BTaggingEff_Num_udsg->Fill(tjet->p4.pt(), std::fabs(tjet->p4.eta()));			   
-		}
-	      }
+        KJet* tjet = static_cast<KJet*>(*jet);
+        float combinedSecondaryVertex = tjet->getTag(settings.GetBTaggedJetCombinedSecondaryVertexName(), event.m_jetMetadata);
+
+        int jet_flavor = tjet->hadronFlavour;
+        float jet_pt = tjet->p4.pt();
+        float jet_eta = std::fabs(tjet->p4.eta());
+        bool passed_btag_wp = combinedSecondaryVertex > bTaggingWorkingPoint;
+
+        if (jet_flavor == 5)
+        {
+            m_BTaggingEff_Denom_b->Fill(jet_pt, jet_eta);
+            if (passed_btag_wp)
+                m_BTaggingEff_Num_b->Fill(jet_pt, jet_eta);
+        }
+        else if (jet_flavor == 4)
+        {
+            m_BTaggingEff_Denom_c->Fill(jet_pt, jet_eta);
+            if (passed_btag_wp)
+                m_BTaggingEff_Num_c->Fill(jet_pt, jet_eta);
+        }
+        else
+        {
+            m_BTaggingEff_Denom_udsg->Fill(jet_pt, jet_eta);
+            if (passed_btag_wp)
+                m_BTaggingEff_Num_udsg->Fill(jet_pt, jet_eta);
+        }
     }
 }
 
 void BTagEffConsumer::Finish(setting_type const& settings)
 {
-	RootFileHelper::SafeCd(settings.GetRootOutFile(), settings.GetRootFileFolder());
-  m_BTaggingEff_Denom_b->Write(m_BTaggingEff_Denom_b->GetName());
-  m_BTaggingEff_Denom_c->Write(m_BTaggingEff_Denom_c->GetName());
-  m_BTaggingEff_Denom_udsg->Write(m_BTaggingEff_Denom_udsg->GetName());
-  m_BTaggingEff_Num_b->Write(m_BTaggingEff_Num_b->GetName());
-  m_BTaggingEff_Num_c->Write(m_BTaggingEff_Num_c->GetName());
-  m_BTaggingEff_Num_udsg->Write(m_BTaggingEff_Num_udsg->GetName());
+    RootFileHelper::SafeCd(settings.GetRootOutFile(), settings.GetRootFileFolder());
+    m_BTaggingEff_Denom_b->Write(m_BTaggingEff_Denom_b->GetName());
+    m_BTaggingEff_Denom_c->Write(m_BTaggingEff_Denom_c->GetName());
+    m_BTaggingEff_Denom_udsg->Write(m_BTaggingEff_Denom_udsg->GetName());
+    m_BTaggingEff_Num_b->Write(m_BTaggingEff_Num_b->GetName());
+    m_BTaggingEff_Num_c->Write(m_BTaggingEff_Num_c->GetName());
+    m_BTaggingEff_Num_udsg->Write(m_BTaggingEff_Num_udsg->GetName());
 }
 
 std::string BTagEffConsumer::GetConsumerId() const
 {
-	return "BTagEffConsumer";
+    return "BTagEffConsumer";
 }

--- a/src/Producers/TaggedJetUncertaintyShiftProducer.cc
+++ b/src/Producers/TaggedJetUncertaintyShiftProducer.cc
@@ -19,26 +19,26 @@ std::string TaggedJetUncertaintyShiftProducer::GetProducerId() const
 void TaggedJetUncertaintyShiftProducer::Init(setting_type const& settings)
 {
 	ProducerBase<HttTypes>::Init(settings);
-	
+
+	// Settings JEC
 	uncertaintyFile = settings.GetJetEnergyCorrectionSplitUncertaintyParameters();
 	individualUncertainties = settings.GetJetEnergyCorrectionSplitUncertaintyParameterNames();
-
-	// make sure the necessary parameters are configured
 	assert(uncertaintyFile != "");
 	assert(individualUncertainties.size() > 0);
 
+	// Settings Jet ID
 	jetIDVersion = KappaEnumTypes::ToJetIDVersion(boost::algorithm::to_lower_copy(boost::algorithm::trim_copy(settings.GetJetIDVersion())));
 	jetID = KappaEnumTypes::ToJetID(boost::algorithm::to_lower_copy(boost::algorithm::trim_copy(settings.GetJetID())));
-
-	// implementation not nice at the moment. feel free to improve it :)
 	lowerPtCuts = Utility::ParseMapTypes<std::string, float>(Utility::ParseVectorToMap(settings.GetJetLowerPtCuts()));
 	upperAbsEtaCuts = Utility::ParseMapTypes<std::string, float>(Utility::ParseVectorToMap(settings.GetJetUpperAbsEtaCuts()));
 
 	if (lowerPtCuts.size() > 1)
 		LOG(FATAL) << "TaggedJetUncertaintyShiftProducer: lowerPtCuts.size() = " << lowerPtCuts.size() << ". Current implementation requires it to be <= 1.";
+
 	if (upperAbsEtaCuts.size() > 1)
-		LOG(FATAL) << "TaggedJetUncertaintyShiftProducer: upperAbsEtaCuts.size() = " << upperAbsEtaCuts.size() << ". Current implementation requires it to be <= 1.";
-	
+               LOG(FATAL) << "TaggedJetUncertaintyShiftProducer: upperAbsEtaCuts.size() = " << upperAbsEtaCuts.size() << ". Current implementation requires it to be <= 1.";
+
+	// Settings BTagged Jet ID
 	// some inputs needed for b-tagging
 	std::map<std::string, std::vector<float> > bTagWorkingPointsTmp = Utility::ParseMapTypes<std::string, float>(
 			Utility::ParseVectorToMap(settings.GetBTaggerWorkingPoints())
@@ -51,6 +51,7 @@ void TaggedJetUncertaintyShiftProducer::Init(setting_type const& settings)
 	{
 		m_bTagSf = BTagSF(settings.GetBTagScaleFactorFile(), settings.GetBTagEfficiencyFile());
 		m_bTagWorkingPoint = bTagWorkingPointsTmp.begin()->second.at(0);
+
 		if (settings.GetApplyBTagSF() && !settings.GetInputIsData())
 		{
 			m_bTagSFMethod = KappaEnumTypes::ToBTagScaleFactorMethod(boost::algorithm::to_lower_copy(boost::algorithm::trim_copy(settings.GetBTagSFMethod())));
@@ -60,13 +61,12 @@ void TaggedJetUncertaintyShiftProducer::Init(setting_type const& settings)
 
 	for (auto const& uncertainty : individualUncertainties)
 	{
-		// only do string comparison once per uncertainty
+		// Construct list of enum individual uncertainties
 		HttEnumTypes::JetEnergyUncertaintyShiftName individualUncertainty = HttEnumTypes::ToJetEnergyUncertaintyShiftName(uncertainty);
-		if (individualUncertainty == HttEnumTypes::JetEnergyUncertaintyShiftName::NONE)
-			continue;
+		if (individualUncertainty == HttEnumTypes::JetEnergyUncertaintyShiftName::NONE) continue;
 		individualUncertaintyEnums.push_back(individualUncertainty);
 
-		// create uncertainty map (only if shifts are to be applied)
+               // Create uncertainty map (only if shifts are to be applied)
 		if (settings.GetJetEnergyCorrectionSplitUncertainty()
 			&& settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0
 			&& individualUncertainty != HttEnumTypes::JetEnergyUncertaintyShiftName::Closure)
@@ -78,7 +78,7 @@ void TaggedJetUncertaintyShiftProducer::Init(setting_type const& settings)
 			JetUncMap[individualUncertainty] = jecUnc;
 		}
 
-		// add quantities to event
+		// Add quantities to event
 		std::string njetsQuantity = "njetspt30_" + uncertainty;
 		LambdaNtupleConsumer<HttTypes>::AddIntQuantity(njetsQuantity, [individualUncertainty](event_type const& event, product_type const& product)
 		{
@@ -129,15 +129,14 @@ void TaggedJetUncertaintyShiftProducer::Init(setting_type const& settings)
 void TaggedJetUncertaintyShiftProducer::Produce(event_type const& event, product_type& product,
 		setting_type const& settings) const
 {
-	// only do all of this if uncertainty shifts should be applied
+       // Only do all of this if uncertainty shifts should be applied
 	if (settings.GetJetEnergyCorrectionSplitUncertainty() && settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0)
 	{
-		// shift copies of previously corrected jets
+		// Shifting copies of previously corrected jets
 		std::vector<double> closureUncertainty((product.m_correctedTaggedJets).size(), 0.);
 		for (auto const& uncertainty : individualUncertaintyEnums)
 		{
-
-			// construct copies of jets in order not to modify actual (corrected) jets
+                       // Construct copies of jets in order not to modify actual (corrected) jets by the uncertainty
 			std::vector<KJet*> copiedJets;
 			for (typename std::vector<std::shared_ptr<KJet> >::iterator jet = (product.m_correctedTaggedJets).begin();
 				 jet != (product.m_correctedTaggedJets).end(); ++jet)
@@ -149,85 +148,71 @@ void TaggedJetUncertaintyShiftProducer::Produce(event_type const& event, product
 			for (std::vector<KJet*>::iterator jet = copiedJets.begin(); jet != copiedJets.end(); ++jet, ++iJet)
 			{
 				double unc = 0;
-
 				if (std::abs((*jet)->p4.Eta()) < 5.2 && (*jet)->p4.Pt() > 9. && uncertainty != HttEnumTypes::JetEnergyUncertaintyShiftName::Closure)
 				{
 					JetUncMap.at(uncertainty)->setJetEta((*jet)->p4.Eta());
 					JetUncMap.at(uncertainty)->setJetPt((*jet)->p4.Pt());
 					unc = JetUncMap.at(uncertainty)->getUncertainty(true);
 				}
-				closureUncertainty.at(iJet) = closureUncertainty.at(iJet) + unc*unc;
+				closureUncertainty.at(iJet) = closureUncertainty.at(iJet) + pow(unc, 2);
 
+				// Evaluating in last loop iteration if evaluated
 				if (uncertainty == HttEnumTypes::JetEnergyUncertaintyShiftName::Closure)
-				{
 					unc = std::sqrt(closureUncertainty.at(iJet));
-				}
+
+				// Varying just the 4-momenta by uncertainty
 				(*jet)->p4 = (*jet)->p4 * (1 + unc * settings.GetJetEnergyCorrectionUncertaintyShift());
 			}
-			// sort vectors of shifted jets by pt
+                       // Sort vectors of shifted jets (shifted_copied_jets holds jets varied maximum by one uncertainty) by pt
 			std::sort(copiedJets.begin(), copiedJets.end(),
 					  [](KJet* jet1, KJet* jet2) -> bool
-					  { return jet1->p4.Pt() > jet2->p4.Pt(); });
+					  { return jet1->p4.Pt() > jet2->p4.Pt(); }
+			);
 
-			// create new vector with shifted jets that pass ID as in ValidJetsProducer
+			// Create new vector from shifted jets that pass ID as in ValidJetsProducer
 			std::vector<KJet*> shiftedJets;
 			std::vector<KJet*> shiftedBTaggedJets;
 			for (std::vector<KJet*>::iterator jet = copiedJets.begin(); jet != copiedJets.end(); ++jet)
 			{
 				bool validJet = true;
 
-				// passed jet id?
+				// Passing jet ID
 				validJet = validJet && ValidJetsProducer::passesJetID(*jet, jetIDVersion, jetID);
 
-				// kinematic cuts
-				// implementation not nice at the moment. feel free to improve it :)
+				// Kinematical cuts
 				for (std::map<std::string, std::vector<float> >::const_iterator lowerPtCut = lowerPtCuts.begin(); lowerPtCut != lowerPtCuts.end() && validJet; ++lowerPtCut)
-				{
 					if ((*jet)->p4.Pt() < *std::max_element(lowerPtCut->second.begin(), lowerPtCut->second.end()))
-					{
 						validJet = false;
-					}
-				}
+
 				for (std::map<std::string, std::vector<float> >::const_iterator upperAbsEtaCut = upperAbsEtaCuts.begin(); upperAbsEtaCut != upperAbsEtaCuts.end() && validJet; ++upperAbsEtaCut)
-				{
 					if (std::abs((*jet)->p4.Eta()) > *std::min_element(upperAbsEtaCut->second.begin(), upperAbsEtaCut->second.end()))
-					{
 						validJet = false;
-					}
-				}
 
-				// remove leptons from list of jets via simple DeltaR isolation
-				for (std::vector<KLepton*>::const_iterator lepton = product.m_validLeptons.begin();
-					 validJet && lepton != product.m_validLeptons.end(); ++lepton)
-				{
+				// Remove leptons from list of jets via simple DeltaR isolation eg failed -> is lepton not a jet
+				for (std::vector<KLepton*>::const_iterator lepton = product.m_validLeptons.begin(); validJet && lepton != product.m_validLeptons.end(); ++lepton)
 					validJet = validJet && ROOT::Math::VectorUtil::DeltaR((*jet)->p4, (*lepton)->p4) > settings.GetJetLeptonLowerDeltaRCut();
-				}
 
-				// apply additional criteria if needed (check ValidTaggedJetsProducer settings)
+				// Apply additional criteria if needed (check ValidTaggedJetsProducer settings)
+				if (validJet) shiftedJets.push_back(*jet);
 
-				if (validJet)
-				{
-					shiftedJets.push_back(*jet);
-				}
 				if (settings.GetUseJECShiftsForBJets())
 				{
-					// determine if jet is btagged
-					bool validBJet = true;
 					KJet* tjet = static_cast<KJet*>(*jet);
 
+					// Determine if jet is btagged
+					bool validBJet = true;
 					float combinedSecondaryVertex = tjet->getTag(settings.GetBTaggedJetCombinedSecondaryVertexName(), event.m_jetMetadata);
 
-					if (combinedSecondaryVertex < m_bTagWorkingPoint ||
-						std::abs(tjet->p4.eta()) > settings.GetBTaggedJetAbsEtaCut()) {
+					if (combinedSecondaryVertex < m_bTagWorkingPoint || std::abs(tjet->p4.eta()) > settings.GetBTaggedJetAbsEtaCut())
 						validBJet = false;
-					}
 
-					//entry point for Scale Factor (SF) of btagged jets
+					// Entry point for Scale Factor (SF) of btagged jets
 					if (settings.GetApplyBTagSF() && !settings.GetInputIsData())
 					{
 						//https://twiki.cern.ch/twiki/bin/view/CMS/BTagSFMethods#2a_Jet_by_jet_updating_of_the_b
-						if (m_bTagSFMethod == KappaEnumTypes::BTagScaleFactorMethod::PROMOTIONDEMOTION) {
-						
+						if (m_bTagSFMethod == KappaEnumTypes::BTagScaleFactorMethod::PROMOTIONDEMOTION)
+						{
+
 							int jetflavor = tjet->hadronFlavour;
 							unsigned int btagSys = BTagSF::kNo;
 							unsigned int bmistagSys = BTagSF::kNo;
@@ -243,23 +228,24 @@ void TaggedJetUncertaintyShiftProducer::Produce(event_type const& event, product
 									settings.GetYear(),
 									m_bTagWorkingPoint
 							);
-							
-							if (taggedBefore != validBJet)
-								LOG_N_TIMES(20, DEBUG) << "Promoted/demoted : " << validBJet;
+
+							if (taggedBefore != validBJet) LOG_N_TIMES(20, DEBUG) << "Promoted/demoted : " << validBJet;
 						}
-						
-						else if (m_bTagSFMethod == KappaEnumTypes::BTagScaleFactorMethod::OTHER) {
-							//todo
+						else if (m_bTagSFMethod == KappaEnumTypes::BTagScaleFactorMethod::OTHER)
+						{
+							// TODO
 						}
 					}
 
-					if (validBJet) {
+					if (validBJet)
+					{
 						shiftedBTaggedJets.push_back(tjet);
-						validJet = true; //mark jet as not to be deleted
+						validJet = true; // Mark jet as not to be deleted
 					}
 				}
-				//delete non valid (b)jets
-				if(!validJet) delete *jet;
+
+				// Delete non valid (b)jets
+				if (!validJet) delete *jet;
 			}
 
 			(product.m_correctedJetsBySplitUncertainty)[uncertainty] = shiftedJets;


### PR DESCRIPTION
Here is summarised all the things that are needed for the b-tag eff files productions.


An example command to run in batch:
```
 HiggsToTauTauAnalysis.py \
-i  HiggsAnalysis/KITHiggsToTauTau/data/Samples/Fall17v2/*Fall17MiniAODv2*.txt  \
HiggsAnalysis/KITHiggsToTauTau/data/Samples/Run2017/ReReco_31Mar2018/{Tau,Single,MuonEG}*.txt \
-a HiggsAnalysis/KITHiggsToTauTau/python/data/ArtusConfigs/Run2MSSM2017_base.py \
-b naf \
--wall-time 02:59:00 \
--memory 1990 \
--work $ARTUS_WORK_BASE/BTagEff_control \
--project-name DeepCSV_tight \
--no-svfit \
--analysis-channels mt et tt em \
--sub-analysis btag-eff
```

I added the possibility of passing arbitrary parameters to configs builder so it would be easy to adjust some setting for some small studies without copying configs.

What you should know about `--no-svfit` : basically it just removes the producer and removes HAS HARDCODED svfit quantities (since it doesn't directly belong to the btagging I would rather fix separately)