### PR TITLE
add functionality to only run relevant channels in data and embedded

### DIFF
--- a/python/data/ArtusConfigs/Run2LegacyAnalysis_base.py
+++ b/python/data/ArtusConfigs/Run2LegacyAnalysis_base.py
@@ -178,7 +178,7 @@ def build_config(nickname, **kwargs):
       config["Generator"] = "amcatnlo"
 
 
-  if isData or is Embedded:
+  if isData or isEmbedded:
     if re.search("(DoubleEG|ElectronEmbedding)", nickname):
       allowed_channels = ["ee"]
     elif re.search("(MuonEG|ElMuFinalState)", nickname):

--- a/python/data/ArtusConfigs/Run2LegacyAnalysis_base.py
+++ b/python/data/ArtusConfigs/Run2LegacyAnalysis_base.py
@@ -183,12 +183,12 @@ def build_config(nickname, **kwargs):
       allowed_channels = ["ee"]
     elif re.search("(MuonEG|ElMuFinalState)", nickname):
       allowed_channels = ["em"]
-    elif re.search("(SingleElectron|ElTauFinalState)", nickname):
-      allowed_channels = ["et"]
+    elif re.search("(SingleElectron|EGamma|ElTauFinalState)", nickname):
+      allowed_channels = ["ee", "et"]
     elif re.search("(DoubleMuon|MuonEmbedding)", nickname):
       allowed_channels = ["mm"]
     elif re.search("(SingleMuon|MuTauFinalState)", nickname):
-      allowed_channels = ["mt"]
+      allowed_channels = ["mm", "mt"]
     elif re.search("(^Tau|TauTauFinalState)", nickname):
       allowed_channels = ["et", "mt", "tt"]
     else:

--- a/python/data/ArtusConfigs/Run2LegacyAnalysis_base.py
+++ b/python/data/ArtusConfigs/Run2LegacyAnalysis_base.py
@@ -178,6 +178,27 @@ def build_config(nickname, **kwargs):
       config["Generator"] = "amcatnlo"
 
 
+  if isData or is Embedded:
+    if re.search("(DoubleEG|ElectronEmbedding)", nickname):
+      allowed_channels = ["ee"]
+    elif re.search("(MuonEG|ElMuFinalState)", nickname):
+      allowed_channels = ["em"]
+    elif re.search("(SingleElectron|ElTauFinalState)", nickname):
+      allowed_channels = ["et"]
+    elif re.search("(DoubleMuon|MuonEmbedding)", nickname):
+      allowed_channels = ["mm"]
+    elif re.search("(SingleMuon|MuonEmbedding)", nickname):
+      allowed_channels = ["mt"]
+    elif re.search("(^Tau|TauTauFinalState)", nickname):
+      allowed_channels = ["et", "mt", "tt"]
+    else:
+      print "Unknown format of nickname %s for type data or embedded!"
+      raise Exception
+    if "all" in analysis_channels:
+      analysis_channels = allowed_channels
+    else:
+      analysis_channels=list(set(analysis_channels).intersection(set(allowed_channels)))  
+
   # pipelines - channels including systematic shifts
   config["Pipelines"] = jsonTools.JsonDict()
   if "all" in analysis_channels or "ee" in analysis_channels: config["Pipelines"] += importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2LegacyAnalysis.%s.ee"%str(year)).build_config(nickname, **kwargs)

--- a/python/data/ArtusConfigs/Run2LegacyAnalysis_base.py
+++ b/python/data/ArtusConfigs/Run2LegacyAnalysis_base.py
@@ -187,7 +187,7 @@ def build_config(nickname, **kwargs):
       allowed_channels = ["et"]
     elif re.search("(DoubleMuon|MuonEmbedding)", nickname):
       allowed_channels = ["mm"]
-    elif re.search("(SingleMuon|MuonEmbedding)", nickname):
+    elif re.search("(SingleMuon|MuTauFinalState)", nickname):
       allowed_channels = ["mt"]
     elif re.search("(^Tau|TauTauFinalState)", nickname):
       allowed_channels = ["et", "mt", "tt"]


### PR DESCRIPTION
Artur und ich hatten es davon, dass es sinnvoll wäre, bei Daten (bei embedded vmtl auch) nur die tatsächlich verwendeten channels in Artus zu prozessieren. Das würde insbesondere dem friend-tree-producer helfen, nur sinnvolle jobs abzuschicken. Schaut bitte mal auf diese filter-Funktion in der Artus-Config, ob die so ok ist und ob ihr generell mit dieser Änderung einverstanden seid.