### PR TITLE
add readout of leptonJets

### DIFF
--- a/interface/HttProduct.h
+++ b/interface/HttProduct.h
@@ -107,6 +107,7 @@ public:
 	bool m_diLeptonGenSystemFound = false;
 	RMFLV m_diTauGenSystem;
 	bool m_diTauGenSystemFound = false;
+	std::vector<KBasicJet*> m_LeptonJets;
 
 	// filled by the TauSpinnerProducer
 	double m_tauSpinnerPolarisation = DefaultValues::UndefinedDouble;

--- a/python/data/ArtusConfigs/Run2LegacyAnalysis/Includes/syncQuantities.py
+++ b/python/data/ArtusConfigs/Run2LegacyAnalysis/Includes/syncQuantities.py
@@ -68,6 +68,10 @@ def build_list(**kwargs):
         "mTdileptonMET",
         "mTdileptonMET_puppi",
         "DiTauDeltaR",
+        "taujet_pt_1",
+        "taujet_eta_1",
+        "taujet_pt_2",
+        "taujet_eta_2"
     ]
 
     quantities.extend(importlib.import_module("HiggsAnalysis.KITHiggsToTauTau.data.ArtusConfigs.Run2LegacyAnalysis.Includes.weightQuantities").build_list(minimal_setup=minimal_setup, isMC=kwargs["isMC"]))

--- a/src/Producers/DiLeptonQuantitiesProducer.cc
+++ b/src/Producers/DiLeptonQuantitiesProducer.cc
@@ -150,8 +150,19 @@ void DiLeptonQuantitiesProducer::Init(setting_type const& settings)
 	LambdaNtupleConsumer<HttTypes>::AddFloatQuantity("puppirecoilParToZ", [](event_type const& event, product_type const& product) {
 		return product.puppirecoilParToZ;
 	});
+	LambdaNtupleConsumer<HttTypes>::AddFloatQuantity("taujet_pt_1", [](event_type const& event, product_type const& product) {
+		return ((product.m_LeptonJets.at(0) != static_cast<KBasicJet*>(nullptr)) ? product.m_LeptonJets.at(0)->p4.Pt() : DefaultValues::UndefinedFloat);
+	});
+	LambdaNtupleConsumer<HttTypes>::AddFloatQuantity("taujet_eta_1", [](event_type const& event, product_type const& product) {
+		return ((product.m_LeptonJets.at(0) != static_cast<KBasicJet*>(nullptr)) ? product.m_LeptonJets.at(0)->p4.Eta() : DefaultValues::UndefinedFloat);
+	});
+	LambdaNtupleConsumer<HttTypes>::AddFloatQuantity("taujet_pt_2", [](event_type const& event, product_type const& product) {
+		return ((product.m_LeptonJets.at(1) != static_cast<KBasicJet*>(nullptr)) ? product.m_LeptonJets.at(1)->p4.Pt() : DefaultValues::UndefinedFloat);
+	});
+	LambdaNtupleConsumer<HttTypes>::AddFloatQuantity("taujet_eta_2", [](event_type const& event, product_type const& product) {
+		return ((product.m_LeptonJets.at(1) != static_cast<KBasicJet*>(nullptr)) ? product.m_LeptonJets.at(1)->p4.Eta() : DefaultValues::UndefinedFloat);
+	});
 }
-
 void DiLeptonQuantitiesProducer::Produce(event_type const& event, product_type& product,
 	                                     setting_type const& settings) const
 {
@@ -246,4 +257,10 @@ void DiLeptonQuantitiesProducer::Produce(event_type const& event, product_type& 
 	                                                - product.m_puppimet.p4 - product.m_flavourOrderedLeptons[0]->p4 - product.m_flavourOrderedLeptons[1]->p4);
 	product.puppirecoilParToZ = Quantities::MetParToZ(product.m_flavourOrderedLeptons[0]->p4, product.m_flavourOrderedLeptons[1]->p4,
 	                                                - product.m_puppimet.p4 - product.m_flavourOrderedLeptons[0]->p4 - product.m_flavourOrderedLeptons[1]->p4);
+
+	for (auto lepton: product.m_flavourOrderedLeptons)
+    {
+		auto matchingjet = product.m_leptonJetsMap.find(lepton);
+		product.m_LeptonJets.push_back(matchingjet->second);
+    }
 }


### PR DESCRIPTION
This PR depends on the Artus PR: https://github.com/KIT-CMS/Artus/pull/24 

Readsout the leptonjets for the two leptons of the `m_flavourOrderedLeptons` and stores the pt and eta of both jets in the ntuple